### PR TITLE
Warning added to avoid silent unavailability of intellij tasks.

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
@@ -59,6 +59,8 @@ class IntelliJPlugin implements Plugin<Project> {
                 configurePrepareSandboxTask(it)
                 configureRunIdeaTask(it)
                 configureBuildPluginTask(it, extension)
+            } else {
+                LOG.warn("File not found: plugin.xml. IntelliJ specific tasks will be unavailable.")
             }
         }
     }

--- a/src/test/groovy/org/jetbrains/intellij/IntelliJPluginSpec.groovy
+++ b/src/test/groovy/org/jetbrains/intellij/IntelliJPluginSpec.groovy
@@ -19,6 +19,7 @@ class IntelliJPluginSpec extends IntelliJPluginSpecBase {
 
         then:
         tasks(IntelliJPlugin.GROUP_NAME) == null
+        stdout.contains('specific tasks will be unavailable')
     }
 
     def 'instrument code with nullability annotations'() {


### PR DESCRIPTION
The first time that I have tried the plugin I was unable to use the intellij tasks because of the non standard location of my plugin.xml file. This warning would... warn the user of the otherwise silent unavailability of the intellij tasks.