### PR TITLE
IntelliJPluginExtension: Suppress unused declaration warnings for whole class

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPluginExtension.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPluginExtension.groovy
@@ -1,5 +1,6 @@
 package org.jetbrains.intellij
 
+@SuppressWarnings("GroovyUnusedDeclaration")
 class IntelliJPluginExtension {
     String[] plugins
     String version
@@ -35,7 +36,6 @@ class IntelliJPluginExtension {
         return runClasspath
     }
 
-    @SuppressWarnings("GroovyUnusedDeclaration")
     def publish(Closure c) {
         publish.with(c)
     }
@@ -46,22 +46,18 @@ class IntelliJPluginExtension {
         String password
         String channel
 
-        @SuppressWarnings("GroovyUnusedDeclaration")
         def pluginId(String pluginId) {
             this.pluginId = pluginId
         }
 
-        @SuppressWarnings("GroovyUnusedDeclaration")
         def username(String username) {
             this.username = username
         }
 
-        @SuppressWarnings("GroovyUnusedDeclaration")
         def password(String password) {
             this.password = password
         }
 
-        @SuppressWarnings("GroovyUnusedDeclaration")
         def channel(String channel) {
             this.channel = channel
         }


### PR DESCRIPTION
This PR moves the `@SuppressWarnings("GroovyUnusedDeclaration")` annotation from the individual members to the class itself to prevent more unused member warnings.