### PR TITLE
External plugins dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ compileGroovy {
 repositories {
     maven { url 'http://repo.labs.intellij.net/central-proxy' }
     mavenCentral()
+    mavenLocal()
 }
 
 dependencies {
@@ -21,7 +22,7 @@ dependencies {
     compile 'org.jetbrains:annotations:13.0'
     compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
     compile 'org.apache.httpcomponents:httpmime:4.5.1'
-    testCompile 'org.spockframework:spock-core:1.0-groovy-2.3', {
+    testCompile 'org.spockframework:spock-core:1.0-groovy-2.4', {
         exclude module: 'groovy-all'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     compile localGroovy()
     compile 'org.jetbrains:annotations:13.0'
 
-    compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
     compile 'org.jetbrains.intellij:plugin-repository-rest-client:0.3.16'
     compile 'org.jetbrains.intellij.plugins:intellij-plugin-structure:1.14'
     compile 'org.jetbrains.intellij.plugins:common-utils:1.18'

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     }
 }
 
-version = '0.0.42'
+version = '0.0.42-SNAPSHOT'
 group = 'org.jetbrains'
 
 pluginBundle {

--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
@@ -212,7 +212,7 @@ class IntelliJPlugin implements Plugin<Project> {
             description = "Bundles the project as a distribution."
             group = GROUP_NAME
             baseName = extension.pluginName
-            from("$prepareSandboxTask.destinationDir")
+            from("$prepareSandboxTask.destinationDir/$extension.pluginName")
             into(extension.pluginName)
             dependsOn(prepareSandboxTask) 
         }

--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
@@ -112,12 +112,12 @@ class IntelliJPlugin implements Plugin<Project> {
         def ivyFile = createIvyRepo(project, extension)
         def version = extension.version
 
-        project.configurations.create("provided")
+        def externalPluginScope = project.configurations.create("externalPluginScope")
 
         project.sourceSets.configure {
-            main.compileClasspath += project.configurations.getByName("provided")
-            test.compileClasspath += project.configurations.getByName("provided")
-            test.runtimeClasspath += project.configurations.getByName("provided")
+            main.compileClasspath += externalPluginScope
+            test.compileClasspath += externalPluginScope
+            test.runtimeClasspath += externalPluginScope
         }
 
         project.repositories.ivy { repo ->
@@ -141,7 +141,7 @@ class IntelliJPlugin implements Plugin<Project> {
         ])
 
         extension.externalPlugins.each {
-            project.dependencies.add("provided", project.files(downloadExternalPlugin(project, it)))
+            project.dependencies.add("externalPluginScope", project.files(downloadExternalPlugin(project, it)))
         }
     }
 
@@ -310,7 +310,7 @@ class IntelliJPlugin implements Plugin<Project> {
 
         new File("$project.projectDir/externalPluginsLibs/").mkdirs()
 
-        new AntBuilder().get(src:"$host/plugin/download?pluginId=$plugin.id&version=$plugin.version", dest:"$project.projectDir/externalPluginsLibs/$plugin.id.$plugin.type", skipexisting:true)
+        project.ant.get(src:"$host/plugin/download?pluginId=$plugin.id&version=$plugin.version", dest:"$project.projectDir/externalPluginsLibs/$plugin.id.$plugin.type", skipexisting:true)
 
         return extractExternalPluginJars(project, plugin)
     }
@@ -320,7 +320,7 @@ class IntelliJPlugin implements Plugin<Project> {
             return [new File("$project.projectDir/externalPluginsLibs/$plugin.id.$plugin.type")]
         }
 
-        new AntBuilder().unzip(src: "$project.projectDir/externalPluginsLibs/$plugin.id.$plugin.type", dest: "$project.projectDir/externalPluginsLibs/", overwrite: "false")
+        project.ant.unzip(src: "$project.projectDir/externalPluginsLibs/$plugin.id.$plugin.type", dest: "$project.projectDir/externalPluginsLibs/", overwrite: "false")
 
         def libsDir = new File("$project.projectDir/externalPluginsLibs/$plugin.unzipTarget/lib")
 

--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
@@ -38,6 +38,7 @@ class IntelliJPlugin implements Plugin<Project> {
         def intellijExtension = project.extensions.create(EXTENSION_NAME, IntelliJPluginExtension)
         intellijExtension.with {
             plugins = []
+            externalPlugins = []
             version = DEFAULT_IDEA_VERSION
             type = 'IC'
             pluginName = project.name

--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
@@ -112,6 +112,14 @@ class IntelliJPlugin implements Plugin<Project> {
         def ivyFile = createIvyRepo(project, extension)
         def version = extension.version
 
+        project.configurations.create("provided")
+
+        project.sourceSets.configure {
+            main.compileClasspath += project.configurations.getByName("provided")
+            test.compileClasspath += project.configurations.getByName("provided")
+            test.runtimeClasspath += project.configurations.getByName("provided")
+        }
+
         project.repositories.ivy { repo ->
             repo.url = extension.ideaDirectory
             repo.ivyPattern(ivyFile.getAbsolutePath()) // ivy xml
@@ -133,8 +141,7 @@ class IntelliJPlugin implements Plugin<Project> {
         ])
 
         extension.externalPlugins.each {
-            //TODO use provided configuration
-            project.dependencies.add(JavaPlugin.COMPILE_CONFIGURATION_NAME, project.files(downloadExternalPlugin(project, it)))
+            project.dependencies.add("provided", project.files(downloadExternalPlugin(project, it)))
         }
     }
 

--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPluginExtension.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPluginExtension.groovy
@@ -3,6 +3,7 @@ package org.jetbrains.intellij
 @SuppressWarnings("GroovyUnusedDeclaration")
 class IntelliJPluginExtension {
     String[] plugins
+    Map[] externalPlugins
     String version
     String type
     String pluginName

--- a/src/main/groovy/org/jetbrains/intellij/PrepareSandboxTask.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/PrepareSandboxTask.groovy
@@ -15,7 +15,7 @@ class PrepareSandboxTask extends Sync {
     CopySpec libraries
     CopySpec metaInf
 
-    CopySpec externalPlugins
+    def externalPlugins = []
 
     public PrepareSandboxTask() {
         this(NAME, false)
@@ -33,7 +33,12 @@ class PrepareSandboxTask extends Sync {
         libraries = plugin.addChild().into("$extension.pluginName/lib")
         metaInf = plugin.addChild().into("$extension.pluginName/META-INF")
 
-        externalPlugins = rootSpec.into(Utils.pluginsDir(extension, inTests)).from("externalPluginsLibs").exclude("*.zip")
+        extension.externalPlugins.each {
+            externalPlugins << rootSpec
+                    .into(Utils.pluginsDir(extension, inTests))
+                    .from(Utils.cachedPluginDirectory(project, it))
+                    .exclude("*.zip")
+        }
 
         configureClasses(extension, inTests)
         configureLibraries(extension)

--- a/src/main/groovy/org/jetbrains/intellij/PrepareSandboxTask.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/PrepareSandboxTask.groovy
@@ -26,7 +26,7 @@ class PrepareSandboxTask extends Sync {
         group = IntelliJPlugin.GROUP_NAME
         description = "Creates a folder containing the plugins to run Intellij IDEA with."
 
-        def extension = project.extensions.findByName(IntelliJPlugin.EXTENSION_NAME) as IntelliJPluginExtension
+        def extension = project.extensions.getByType(IntelliJPluginExtension)
 
         CopySpecInternal plugin = rootSpec.addChild()
         classes = plugin.addChild().into("$extension.pluginName/classes")
@@ -73,7 +73,7 @@ class PrepareSandboxTask extends Sync {
     }
 
     private void disableIdeUpdate() {
-        def extension = project.extensions.findByName(IntelliJPlugin.EXTENSION_NAME) as IntelliJPluginExtension
+        def extension = project.extensions.getByType(IntelliJPluginExtension)
         def optionsDir = new File(Utils.configDir(extension, false), "options")
         if (!optionsDir.exists() && !optionsDir.mkdirs()) {
             IntelliJPlugin.LOG.error("Cannot disable update checking in host IDE")

--- a/src/main/groovy/org/jetbrains/intellij/PrepareSandboxTask.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/PrepareSandboxTask.groovy
@@ -15,6 +15,8 @@ class PrepareSandboxTask extends Sync {
     CopySpec libraries
     CopySpec metaInf
 
+    CopySpec externalPlugins
+
     public PrepareSandboxTask() {
         this(NAME, false)
     }
@@ -24,12 +26,15 @@ class PrepareSandboxTask extends Sync {
         group = IntelliJPlugin.GROUP_NAME
         description = "Creates a folder containing the plugins to run Intellij IDEA with."
 
-        CopySpecInternal plugin = rootSpec.addChild()
-        classes = plugin.addChild().into("classes")
-        libraries = plugin.addChild().into("lib")
-        metaInf = plugin.addChild().into("META-INF")
-
         def extension = project.extensions.findByName(IntelliJPlugin.EXTENSION_NAME) as IntelliJPluginExtension
+
+        CopySpecInternal plugin = rootSpec.addChild()
+        classes = plugin.addChild().into("$extension.pluginName/classes")
+        libraries = plugin.addChild().into("$extension.pluginName/lib")
+        metaInf = plugin.addChild().into("$extension.pluginName/META-INF")
+
+        externalPlugins = rootSpec.into(Utils.pluginsDir(extension, inTests)).from("externalPluginsLibs").exclude("*.zip")
+
         configureClasses(extension, inTests)
         configureLibraries(extension)
     }
@@ -118,7 +123,7 @@ class PrepareSandboxTask extends Sync {
     }
 
     private void configureClasses(@NotNull IntelliJPluginExtension extension, boolean inTests) {
-        destinationDir = new File(Utils.pluginsDir(extension, inTests), "$extension.pluginName")
+        destinationDir = new File(Utils.pluginsDir(extension, inTests))
         classes.from(Utils.mainSourceSet(project).output)
     }
 

--- a/src/main/groovy/org/jetbrains/intellij/Utils.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/Utils.groovy
@@ -13,6 +13,7 @@ import org.xml.sax.SAXParseException
 import java.util.regex.Pattern
 
 class Utils {
+    public static final String GRADLE_CACHE_DIR = 'caches/modules-2/files-2.1/com.jetbrains.intellij.idea'
     public static final Pattern VERSION_PATTERN = Pattern.compile('^([A-Z]{2})-([0-9.A-z]+)\\s*$')
 
     @NotNull
@@ -177,4 +178,29 @@ class Utils {
         })
         return parser.parse(file)
     }
+
+    @NotNull
+    public static String cachedPluginDirectory(@NotNull Project project, @NotNull Map<String, String> plugin) {
+        def version = plugin.get("version")
+        if (version == null) {
+            version = 'LATEST'
+        }
+        return "$project.gradle.gradleUserHomeDir/$GRADLE_CACHE_DIR/$plugin.id/$version"
+    }
+
+    public static final FileFilter JARS = new FileFilter() {
+        @Override
+        boolean accept(File pathname) {
+            return pathname.getName().endsWith(".jar")
+        }
+    }
+
+    public static final FileFilter DIRECTORIES = new FileFilter() {
+        @Override
+        boolean accept(File pathname) {
+            return pathname.isDirectory()
+        }
+    }
+
+    public static final File[] NO_FILES = new File[0];
 }

--- a/src/main/groovy/org/jetbrains/intellij/Utils.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/Utils.groovy
@@ -15,7 +15,6 @@ import org.xml.sax.SAXParseException
 import java.util.regex.Pattern
 
 class Utils {
-    public static final String GRADLE_CACHE_DIR = 'caches/modules-2/files-2.1/com.jetbrains.intellij.idea'
     public static final Pattern VERSION_PATTERN = Pattern.compile('^([A-Z]{2})-([0-9.A-z]+)\\s*$')
 
     @NotNull
@@ -195,29 +194,11 @@ class Utils {
         return StringUtil.endsWithIgnoreCase(file.name, ".zip")
     }
 
-
-    @NotNull
-    public static String cachedPluginDirectory(@NotNull Project project, @NotNull Map<String, String> plugin) {
-        def version = plugin.get("version")
-        if (version == null) {
-            version = 'LATEST'
+    public static File singleChildIn(File directory) {
+        def files = directory.listFiles()
+        if (files.length != 1) {
+            throw new RuntimeException("Single child expected in $directory");
         }
-        return "$project.gradle.gradleUserHomeDir/$GRADLE_CACHE_DIR/$plugin.id/$version"
+        return files[0]
     }
-
-    public static final FileFilter JARS = new FileFilter() {
-        @Override
-        boolean accept(File pathname) {
-            return pathname.getName().endsWith(".jar")
-        }
-    }
-
-    public static final FileFilter DIRECTORIES = new FileFilter() {
-        @Override
-        boolean accept(File pathname) {
-            return pathname.isDirectory()
-        }
-    }
-
-    public static final File[] NO_FILES = new File[0];
 }

--- a/src/test/groovy/org/jetbrains/intellij/ExternalPluginRepositorySpec.groovy
+++ b/src/test/groovy/org/jetbrains/intellij/ExternalPluginRepositorySpec.groovy
@@ -10,9 +10,9 @@ class ExternalPluginRepositorySpec extends IntelliJPluginSpecBase {
 
         then:
         assert plugin != null
-        assert plugin.file.name == 'org.jetbrains.postfixCompletion-master-0.8-beta.jar'
+        assert plugin.artifact.name == 'intellij-postfix.jar'
         assert collectFilePaths(plugin.jarFiles, repository.cacheDirectory.absolutePath) ==
-                ['/plugins.jetbrains.com/org.jetbrains.postfixCompletion-master-0.8-beta.jar'] as Set
+                ['/plugins.jetbrains.com/org.jetbrains.postfixCompletion-master-0.8-beta/intellij-postfix.jar'] as Set
     }
 
     def 'find zip-type plugin'() {
@@ -24,12 +24,12 @@ class ExternalPluginRepositorySpec extends IntelliJPluginSpecBase {
 
         then:
         assert plugin != null
-        assert plugin.file.name == 'org.intellij.plugins.markdown-master-8.5.0.20160208'
+        assert plugin.artifact.name == 'markdown'
         assert collectFilePaths(plugin.jarFiles, repository.cacheDirectory.absolutePath) ==
-                ['/plugins.jetbrains.com/org.intellij.plugins.markdown-master-8.5.0.20160208/lib/markdown-javafx-preview.jar',
-                 '/plugins.jetbrains.com/org.intellij.plugins.markdown-master-8.5.0.20160208/lib/Loboevolution.jar',
-                 '/plugins.jetbrains.com/org.intellij.plugins.markdown-master-8.5.0.20160208/lib/intellij-markdown.jar',
-                 '/plugins.jetbrains.com/org.intellij.plugins.markdown-master-8.5.0.20160208/lib/markdown.jar'] as Set
+                ['/plugins.jetbrains.com/org.intellij.plugins.markdown-master-8.5.0.20160208/markdown/lib/markdown-javafx-preview.jar',
+                 '/plugins.jetbrains.com/org.intellij.plugins.markdown-master-8.5.0.20160208/markdown/lib/Loboevolution.jar',
+                 '/plugins.jetbrains.com/org.intellij.plugins.markdown-master-8.5.0.20160208/markdown/lib/intellij-markdown.jar',
+                 '/plugins.jetbrains.com/org.intellij.plugins.markdown-master-8.5.0.20160208/markdown/lib/markdown.jar'] as Set
     }
 
     def collectFilePaths(Collection<File> files, String cacheDir) {

--- a/src/test/groovy/org/jetbrains/intellij/PrepareSandboxTaskSpec.groovy
+++ b/src/test/groovy/org/jetbrains/intellij/PrepareSandboxTaskSpec.groovy
@@ -82,6 +82,49 @@ class PrepareSandboxTaskSpec extends IntelliJPluginSpecBase {
               </xi:include>
             </idea-plugin>""");
     }
+
+    def 'prepare sandbox with external plugin'() {
+        given:
+        writeJavaFile()
+        pluginXml << '<idea-plugin version="2"></idea-plugin>'
+        buildFile << """\
+            intellij {
+                externalPlugins = [[id: 'org.intellij.plugins.markdown']]
+            }
+            """.stripIndent()
+        when:
+        def project = run(PrepareSandboxTask.NAME)
+
+        then:
+        File sandbox = new File(project.buildDirectory, IntelliJPlugin.DEFAULT_SANDBOX)
+        assert collectPaths(sandbox).contains('/plugins/markdown/lib/markdown.jar')
+    }
+
+    def 'prepare sandbox with external plugin with specific version'() {
+        given:
+        writeJavaFile()
+        pluginXml << '<idea-plugin version="2"></idea-plugin>'
+        buildFile << """\
+            intellij {
+                externalPlugins = [[id: 'org.intellij.plugins.markdown', version: '8.5.0.20160208']]
+            }
+            """.stripIndent()
+        when:
+        def project = run(PrepareSandboxTask.NAME)
+
+        then:
+        File sandbox = new File(project.buildDirectory, IntelliJPlugin.DEFAULT_SANDBOX)
+        assert collectPaths(sandbox).containsAll([
+                '/plugins/markdown/lib/default.css',
+                '/plugins/markdown/lib/darcula.css',
+                '/plugins/markdown/lib/processLinks.js',
+                '/plugins/markdown/lib/scrollToElement.js',
+                '/plugins/markdown/lib/markdown.jar',
+                '/plugins/markdown/lib/markdown-javafx-preview.jar',
+                '/plugins/markdown/lib/intellij-markdown.jar',
+                '/plugins/markdown/lib/Loboevolution.jar'
+        ])
+    }
     
     def 'test transitive xml dependencies'() {
         given:

--- a/src/test/groovy/org/jetbrains/intellij/PrepareSandboxTaskSpec.groovy
+++ b/src/test/groovy/org/jetbrains/intellij/PrepareSandboxTaskSpec.groovy
@@ -83,13 +83,13 @@ class PrepareSandboxTaskSpec extends IntelliJPluginSpecBase {
             </idea-plugin>""");
     }
 
-    def 'prepare sandbox with external plugin'() {
+    def 'prepare sandbox with external jar-type plugin'() {
         given:
         writeJavaFile()
         pluginXml << '<idea-plugin version="2"></idea-plugin>'
         buildFile << """\
             intellij {
-                externalPlugins = [[id: 'org.intellij.plugins.markdown']]
+                externalPlugins = [[id: 'org.jetbrains.postfixCompletion', version: '0.8-beta']]
             }
             """.stripIndent()
         when:
@@ -97,10 +97,12 @@ class PrepareSandboxTaskSpec extends IntelliJPluginSpecBase {
 
         then:
         File sandbox = new File(project.buildDirectory, IntelliJPlugin.DEFAULT_SANDBOX)
-        assert collectPaths(sandbox).contains('/plugins/markdown/lib/markdown.jar')
+        assert collectPaths(sandbox).containsAll([
+                '/plugins/intellij-postfix.jar'
+        ])
     }
 
-    def 'prepare sandbox with external plugin with specific version'() {
+    def 'prepare sandbox with external zip-type plugin'() {
         given:
         writeJavaFile()
         pluginXml << '<idea-plugin version="2"></idea-plugin>'


### PR DESCRIPTION
## This pull request is not ready yet. 

Proposed extra configuration to add dependency on external plugin:
```
intellij {
    externalPlugins = [[
                           id: 'org.intellij.plugins.markdown',
                           version: '8.5.0.20160208',
                           type: 'zip',
                           unzipTarget: 'markdown'
                       ],
                       [....]]
}
```