### PR TITLE
Fix suppression of instrumentation of Kotlin classes

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/IntelliJInstrumentCodeAction.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJInstrumentCodeAction.groovy
@@ -76,7 +76,7 @@ class IntelliJInstrumentCodeAction implements Action<Task> {
                 destdir: compileTask.destinationDir, classpath: compileTask.classpath.asPath,
                 includeantruntime: false, instrumentNotNull: instrumentNotNull) {
             if (instrumentNotNull) {
-                compileTask.project.ant.skip(pattern: 'kotlin/jvm/internal/.*')
+                compileTask.project.ant.skip(pattern: 'kotlin/Metadata')
             }
         }
         if (headlessOldValue != null) {


### PR DESCRIPTION
Instead of annotations in `kotlin/jvm/internal/` there is now only `kotlin/Metadata` (https://github.com/JetBrains/kotlin/commit/59dab0a558328b9df4f5540da60bd0dcd4b10a35).