### PR TITLE
Convert version to string to avoid serializing a version object

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/PatchPluginXmlAction.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/PatchPluginXmlAction.groovy
@@ -9,7 +9,7 @@ class PatchPluginXmlAction implements Action<Task> {
     private final Map<String, String> myProperties = new HashMap()
 
     PatchPluginXmlAction(@NotNull Project project) {
-        myProperties.version = project.version
+        myProperties.version = project.version?.toString()
         def extension = project.extensions.findByName(IntelliJPlugin.EXTENSION_NAME) as IntelliJPluginExtension
         if (extension != null && extension.updateSinceUntilBuild) {
             try {


### PR DESCRIPTION
Gradle appears to have a problem deserializing custom objects used as task input properties. To work around this, convert the version to a string when it is set on myproperties.