### PR TITLE
remove references to deprecated and unused 'pluginId'

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Empty value means that the IDE that was used for compiling will be used for runn
 
 #### Publishing plugin
 
-- `intellij.publish.pluginId` defines plugin id at JetBrains plugin repository, you can find it in url of you plugin page there.
 - `intellij.publish.username` your login at JetBrains plugin repository.
 - `intellij.publish.password` your password at JetBrains plugin repository.
 - `intellij.publish.channel` defines channel to upload, you may use any string here, empty string means default channel.
@@ -134,7 +133,6 @@ intellij {
   publish {
     username 'zolotov'
     password 'password'
-    pluginId '5047'
     channel 'nightly'
   } 
 }

--- a/src/main/groovy/org/jetbrains/intellij/PublishTask.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/PublishTask.groovy
@@ -23,7 +23,7 @@ class PublishTask extends DefaultTask {
             boolean misconfigurated = false
             if (extension.publish.pluginId) {
                 IntelliJPlugin.LOG.warn("intellij.publish.pluginId property is deprecated. " +
-                        "id-tag from plugin.xml will be used for uploading")
+                        "Tag 'id' from plugin.xml will be used for uploading.")
             }
             def pluginId = Utils.getPluginId(project)
             if (!pluginId) {
@@ -50,7 +50,7 @@ class PublishTask extends DefaultTask {
             }
 
             def host = "http://plugins.jetbrains.com"
-            IntelliJPlugin.LOG.info("Uploading plugin $extension.publish.pluginId from $distributionFile.absolutePath to $host")
+            IntelliJPlugin.LOG.info("Uploading plugin $pluginId from $distributionFile.absolutePath to $host")
             try {
                 def repoClient = new PluginRepositoryInstance(host, extension.publish.username, extension.publish.password)
                 repoClient.uploadPlugin(pluginId, distributionFile, extension.publish.channel ?: '')


### PR DESCRIPTION
- clarify log message
- do not output old pluginId in log message
- remove references from README