### PR TITLE
Added option "intellij.addToolsJar" for adding tools.jar to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ Empty value means that the IDE that was used for compiling will be used for runn
 distributions. If empty – Gradle cache directory will be used.
 **Default value**: `<empty>`
 
+- `intellij.addToolsJar` – whether to add tools.jar from the current JDK to the dependencies.
+**Default value**: `true`
+
 ### Patching plugin.xml
 
 *Available in SNAPSHOT only*

--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
@@ -54,6 +54,7 @@ class IntelliJPlugin implements Plugin<Project> {
             sameSinceUntilBuild = false
             intellijRepo = DEFAULT_INTELLIJ_REPO
             downloadSources = true
+            addToolsJar = true
             publish = new IntelliJPluginExtension.Publish()
         }
         configureTasks(project, intellijExtension)
@@ -104,7 +105,7 @@ class IntelliJPlugin implements Plugin<Project> {
         resolver.register(project, ideaDependency)
 
         def toolsJar = Jvm.current().toolsJar
-        if (toolsJar) {
+        if (extension.addToolsJar && toolsJar) {
             project.dependencies.add(JavaPlugin.RUNTIME_CONFIGURATION_NAME, project.files(toolsJar))
         }
     }

--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPluginExtension.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPluginExtension.groovy
@@ -21,6 +21,7 @@ class IntelliJPluginExtension {
     boolean updateSinceUntilBuild
     boolean sameSinceUntilBuild
     boolean downloadSources
+    boolean addToolsJar
     Publish publish
 
     IdeaDependency ideaDependency


### PR DESCRIPTION
The automatic dependency on tools.jar does not work if you use the project on multiple machines because it points to a path in the current Gradle JVM which is machine-specific. With this new option you can disable the automatic dependency.