### PR TITLE
IntellijPlugin: Set "downloadSources" to "false" by default if CI is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ which is useful for building plugins against EAP IDEA builds.<br/><br/>
 - `intellij.downloadSources` defines whether plugin should download IntelliJ sources while 
 initializing Gradle build. Since sources are no needed while testing on CI, you can set
 it to `false` for particular environment.<br/><br/>
-**Default value**: `true`
+**Default value**: `true` unless the `CI` environment variable is set
 
 - `intellij.systemProperties` defines the map of system properties which will be passed to IDEA instance on
 executing `runIdea` task and tests.<br/>

--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
@@ -54,7 +54,7 @@ class IntelliJPlugin implements Plugin<Project> {
             updateSinceUntilBuild = true
             sameSinceUntilBuild = false
             intellijRepo = DEFAULT_INTELLIJ_REPO
-            downloadSources = true
+            downloadSources = !System.getenv().containsKey('CI')
             publish = new IntelliJPluginExtension.Publish()
         }
         configureTasks(project, intellijExtension)


### PR DESCRIPTION
This PR essentially makes "Since sources are no needed while testing on CI, you can set
 it to `false` for particular environment." an automatic default. This works on all CI systems that set the `CI` environment variable (e.g. Travis CI, CircleCI, AppVeyor, ...).