### PR TITLE
Adds projectDirectory to open a project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,8 +89,18 @@ task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
 }
 
+task fatJar(type: Jar) {
+    baseName = project.name + '-all'
+    from (configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }) {
+        exclude "META-INF/*.SF"
+        exclude "META-INF/*.DSA"
+        exclude "META-INF/*.RSA"
+    }
+    with jar
+}
+
 artifacts {
-    archives javadocJar, sourcesJar
+    archives javadocJar, sourcesJar, fatJar
 }
 
 uploadArchives {

--- a/build.gradle
+++ b/build.gradle
@@ -89,18 +89,8 @@ task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
 }
 
-task fatJar(type: Jar) {
-    baseName = project.name + '-all'
-    from (configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }) {
-        exclude "META-INF/*.SF"
-        exclude "META-INF/*.DSA"
-        exclude "META-INF/*.RSA"
-    }
-    with jar
-}
-
 artifacts {
-    archives javadocJar, sourcesJar, fatJar
+    archives javadocJar, sourcesJar
 }
 
 uploadArchives {

--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
@@ -199,7 +199,7 @@ class IntelliJPlugin implements Plugin<Project> {
         project.tasks.create(RUN_IDEA_TASK_NAME, RunIdeaTask).with {
             group = GROUP_NAME
             description = "Runs Intellij IDEA with installed plugin."
-            conventionMapping.map("projectDirectory", { Utils.projectDirectory(extension)})
+            conventionMapping.map("projectDirectory", { Utils.projectDirectory(extension) })
             conventionMapping.map("ideaDirectory", { Utils.ideaSdkDirectory(extension) })
             conventionMapping.map("systemProperties", { extension.systemProperties })
             conventionMapping.map("requiredPluginIds", { Utils.getPluginIds(project) })

--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
@@ -199,6 +199,7 @@ class IntelliJPlugin implements Plugin<Project> {
         project.tasks.create(RUN_IDEA_TASK_NAME, RunIdeaTask).with {
             group = GROUP_NAME
             description = "Runs Intellij IDEA with installed plugin."
+            conventionMapping.map("projectDirectory", { Utils.projectDirectory(extension)})
             conventionMapping.map("ideaDirectory", { Utils.ideaSdkDirectory(extension) })
             conventionMapping.map("systemProperties", { extension.systemProperties })
             conventionMapping.map("requiredPluginIds", { Utils.getPluginIds(project) })

--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPluginExtension.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPluginExtension.groovy
@@ -13,6 +13,7 @@ class IntelliJPluginExtension {
     String version
     String type
     String pluginName
+    String projectDirectory
     String sandboxDirectory
     String intellijRepo
     String alternativeIdePath

--- a/src/main/groovy/org/jetbrains/intellij/Utils.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/Utils.groovy
@@ -118,9 +118,26 @@ class Utils {
         return result
     }
 
+    static File projectDirectory(@NotNull IntelliJPluginExtension extension) {
+        def path = extension.projectDirectory
+        IntelliJPlugin.LOG.warn("Trying to assign project path: $path")
+        def dir = new File(path)
+
+        if (path) {
+            if (!dir.exists()) {
+                IntelliJPlugin.LOG.error("Cannot find IntelliJ project: $dir.")
+            } else {
+                return dir
+            }
+        }
+
+        return null
+    }
+
     @NotNull
     static File ideaSdkDirectory(@NotNull IntelliJPluginExtension extension) {
         def path = extension.alternativeIdePath
+        IntelliJPlugin.LOG.warn("Trying to assign alternative IDE path: $path")
         if (path) {
             def dir = new File(path)
             if (dir.getName().endsWith(".app")) {

--- a/src/main/groovy/org/jetbrains/intellij/Utils.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/Utils.groovy
@@ -120,7 +120,6 @@ class Utils {
 
     static File projectDirectory(@NotNull IntelliJPluginExtension extension) {
         def path = extension.projectDirectory
-        IntelliJPlugin.LOG.warn("Trying to assign project path: $path")
         def dir = new File(path)
 
         if (path) {
@@ -137,7 +136,6 @@ class Utils {
     @NotNull
     static File ideaSdkDirectory(@NotNull IntelliJPluginExtension extension) {
         def path = extension.alternativeIdePath
-        IntelliJPlugin.LOG.warn("Trying to assign alternative IDE path: $path")
         if (path) {
             def dir = new File(path)
             if (dir.getName().endsWith(".app")) {

--- a/src/main/groovy/org/jetbrains/intellij/Utils.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/Utils.groovy
@@ -124,7 +124,7 @@ class Utils {
 
         if (path) {
             if (!dir.exists()) {
-                IntelliJPlugin.LOG.error("Cannot find IntelliJ project: $dir.")
+                IntelliJPlugin.LOG.error("Cannot find IntelliJ project: $dir")
             } else {
                 return dir
             }

--- a/src/main/groovy/org/jetbrains/intellij/tasks/RunIdeaTask.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/tasks/RunIdeaTask.groovy
@@ -105,6 +105,7 @@ class RunIdeaTask extends JavaExec {
         configureClasspath()
         configureSystemProperties()
         configureJvmArgs()
+        configureArgs()
         super.exec()
     }
 
@@ -148,5 +149,9 @@ class RunIdeaTask extends JavaExec {
 
     def configureJvmArgs() {
         jvmArgs = Utils.getIdeaJvmArgs(this, getJvmArgs(), getIdeaDirectory())
+    }
+
+    def configureArgs() {
+        args = ["${project.projectDir.path}"]
     }
 }

--- a/src/main/groovy/org/jetbrains/intellij/tasks/RunIdeaTask.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/tasks/RunIdeaTask.groovy
@@ -167,7 +167,6 @@ class RunIdeaTask extends JavaExec {
     }
 
     def configureArgs() {
-        IntelliJPlugin.LOG.warn("Reading from: $projectDirectory")
         def projectDirectory = getProjectDirectory()
         if (projectDirectory) {
             args = ["$projectDirectory"]

--- a/src/main/groovy/org/jetbrains/intellij/tasks/RunIdeaTask.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/tasks/RunIdeaTask.groovy
@@ -6,6 +6,7 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.util.CollectionUtils
+import org.jetbrains.intellij.IntelliJPlugin
 import org.jetbrains.intellij.Utils
 
 class RunIdeaTask extends JavaExec {
@@ -22,6 +23,7 @@ class RunIdeaTask extends JavaExec {
                                          DB: '0xDBE',
                                          AI: 'AndroidStudio']
     private List<Object> requiredPluginIds = []
+    private Object projectDirectory
     private Object ideaDirectory
     private Object configDirectory
     private Object systemDirectory
@@ -40,6 +42,19 @@ class RunIdeaTask extends JavaExec {
 
     void requiredPluginIds(Object... requiredPluginIds) {
         this.requiredPluginIds.addAll(requiredPluginIds as List)
+    }
+
+    @OutputDirectory
+    File getProjectDirectory() {
+        projectDirectory != null ? project.file(projectDirectory) : null
+    }
+
+    void setProjectDirectory(Object projectDirectory) {
+        this.projectDirectory = projectDirectory
+    }
+
+    void projectDirectory(Object projectDirectory) {
+        this.projectDirectory = projectDirectory
     }
 
     @InputDirectory
@@ -152,6 +167,10 @@ class RunIdeaTask extends JavaExec {
     }
 
     def configureArgs() {
-        args = ["${project.projectDir.path}"]
+        IntelliJPlugin.LOG.warn("Reading from: $projectDirectory")
+        def projectDirectory = getProjectDirectory()
+        if (projectDirectory) {
+            args = ["$projectDirectory"]
+        }
     }
 }


### PR DESCRIPTION
As described in #162, I added a `projectDirectory` property under the `IntelliJPluginExtension` that accepts a directory to be passed as an argument to IntelliJ IDEA upon startup, opening a predefined project directory in the IDE. For example, it can be configured to open the surrounding project:

```groovy

apply plugin: 'org.jetbrains.intellij'

intellij {
  projectDirectory = project.projectDir.path
}
```

The intended use case is to immediately start writing code on a project, without installing, setting up and configuring the IDE. This feature is not only useful for plugin development, but for open source projects in general that want to establish a reproducible development environment for their contributors.