### PR TITLE
Update repo URL and add Gradle Script Kotlin note to Minecraft Dev example

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,11 @@ As examples of using this plugin you can check out following projects:
 - [Adb Idea](https://github.com/pbreault/adb-idea) is configured to build and run against stable, beta or preview (canary) releases of Android Studio
 - [Gerrit](https://github.com/uwolfer/gerrit-intellij-plugin) uses Travis CI inclusive automated publishing of releases to GitHub and JetBrains plugin repository (triggered by version tag creation)
 - [.ignore](https://github.com/hsz/idea-gitignore)
-- [Minecraft Development](https://github.com/DemonWav/MinecraftDevIntelliJ) and its [TeamCity build configuration](https://ci.demonwav.com/viewType.html?buildTypeId=MinecraftDevIntelliJ_Build)
-
+- [Minecraft Development](https://github.com/minecraft-dev/MinecraftDev) and its [TeamCity build configuration](https://ci.demonwav.com/viewType.html?buildTypeId=MinecraftDevIntelliJ_Build)
+  - Uses Gradle Script Kotlin
+  - Mixes Java, Kotlin, and Groovy code
+  - Uses Grammar Kit
+  - Uses a Kotlin version not bundled with IntelliJ
 
 # License
 

--- a/src/docs/examples.md
+++ b/src/docs/examples.md
@@ -23,5 +23,8 @@ As examples of using this plugin you can check out following projects:
 - [Adb Idea](https://github.com/pbreault/adb-idea) is configured to build and run against stable, beta or preview (canary) releases of Android Studio
 - [Gerrit](https://github.com/uwolfer/gerrit-intellij-plugin) uses Travis CI inclusive automated publishing of releases to GitHub and JetBrains plugin repository (triggered by version tag creation)
 - [.ignore](https://github.com/hsz/idea-gitignore)
-- [Minecraft Development](https://github.com/DemonWav/MinecraftDevIntelliJ) and its [TeamCity build configuration](https://ci.demonwav.com/viewType.html?buildTypeId=MinecraftDevIntelliJ_Build)
-
+- [Minecraft Development](https://github.com/minecraft-dev/MinecraftDev) and its [TeamCity build configuration](https://ci.demonwav.com/viewType.html?buildTypeId=MinecraftDevIntelliJ_Build)
+  - Uses Gradle Script Kotlin
+  - Mixes Java, Kotlin, and Groovy code
+  - Uses Grammar Kit
+  - Uses a Kotlin version not bundled with IntelliJ


### PR DESCRIPTION
Since moving the repo to the a Github organization, the repo URL has changed.

Seeing the request to add the comment for Gradle Script Kotlin in #163, I added a comment here as well. In addition to using Gradle Script Kotlin, the Minecraft Dev build script also shows examples for:

 * Running Grammar Kit (modified from the IntelliJ Rust plugin)
 * Mixing Java, Kotlin, and Groovy code
 * Using a Kotlin version not bundled with IntelliJ