### PR TITLE
Detect kotlin-stdlib-jre7/jre8 as Kotlin dependency

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/dependency/IdeaDependencyManager.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/dependency/IdeaDependencyManager.groovy
@@ -159,7 +159,7 @@ class IdeaDependencyManager {
         def configurations = project.configurations
         def closure = {
             if ("org.jetbrains.kotlin" == it.group) {
-                return "kotlin-runtime" == it.name || "kotlin-stdlib" == it.name || "kotlin-reflect" == it.name
+                return "kotlin-runtime" == it.name || it.name.startsWith('kotlin-stdlib') || "kotlin-reflect" == it.name
             }
             return false
         }


### PR DESCRIPTION
Currently, if you use the `kotlin-stdlib-jre7` or `kotlin-stdlib-jre8` artifacts from the Kotlin 1.1 beta, you have to define an additional explicit dependency on `kotlin-stdlib` or `kotlin-runtime` to remove IntelliJ's own Kotlin dependency. ([Example](https://github.com/minecraft-dev/MinecraftDev/blob/2016.3/build.gradle.kts#L90-L97))

When we check if the dependency starts with `kotlin-stdlib` it should cover all future `stdlib` dependencies.