### PR TITLE
Fix test classpath

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
@@ -71,7 +71,7 @@ class IntelliJPlugin implements Plugin<Project> {
 
         if (JavaPlugin.hasProperty('COMPILE_ONLY_CONFIGURATION_NAME')) {
             project.configurations.getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom idea, ideaPlugins
-            project.configurations.getByName(JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom idea, ideaPlugins
+            project.configurations.getByName(JavaPlugin.TEST_COMPILE_CONFIGURATION_NAME).extendsFrom idea, ideaPlugins
         } else {
             project.configurations.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME).extendsFrom idea, ideaPlugins
         }


### PR DESCRIPTION
Fixes test classpath by placing idea dependencies on compile (and
runtime) dependencies instead of compileOnly.