### PR TITLE
Setup project plugin dependency for an already evaluated project

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
@@ -79,6 +79,7 @@ class IntelliJPlugin implements Plugin<Project> {
         configurePublishPluginTask(project, extension)
         configureProcessResources(project)
         configureInstrumentation(project, extension)
+        assert !project.state.executed : "afterEvaluate is a no-op for an executed project"
         project.afterEvaluate { configureProjectAfterEvaluate(it, extension) }
     }
 
@@ -130,16 +131,11 @@ class IntelliJPlugin implements Plugin<Project> {
             LOG.info("Configuring IntelliJ plugin $it")
             if (it instanceof Project) {
                 project.dependencies.add(IDEA_PLUGINS_CONFIGURATION_NAME, it)
-                it.afterEvaluate {
-                    if (it.plugins.findPlugin(IntelliJPlugin) == null) {
-                        throw new BuildException("Cannot use $it as a plugin dependency. IntelliJ Plugin is not found." + it.plugins, null)
-                    }
-                    def dependency = new PluginProjectDependency(it)
-                    extension.pluginDependencies.add(dependency)
-                    def dependencySandboxTask = it.tasks.findByName(PREPARE_SANDBOX_TASK_NAME)
-                    project.tasks.withType(PrepareSandboxTask).each {
-                        it.dependsOn(dependencySandboxTask)
-                        it.configureCompositePlugin(dependency)
+                if (it.state.executed) {
+                    configureProjectPluginDependency(project, it, extension)
+                } else {
+                    it.afterEvaluate {
+                        configureProjectPluginDependency(project, it, extension)
                     }
                 }
             } else {
@@ -160,6 +156,21 @@ class IntelliJPlugin implements Plugin<Project> {
                     it.configureExternalPlugin(plugin)
                 }
             }
+        }
+    }
+
+    private static void configureProjectPluginDependency(@NotNull Project project,
+                                                         @NotNull Project dependency,
+                                                         @NotNull IntelliJPluginExtension extension) {
+        if (dependency.plugins.findPlugin(IntelliJPlugin) == null) {
+            throw new BuildException("Cannot use $dependency as a plugin dependency. IntelliJ Plugin is not found." + dependency.plugins, null)
+        }
+        def pluginDependency = new PluginProjectDependency(dependency)
+        extension.pluginDependencies.add(pluginDependency)
+        def dependencySandboxTask = dependency.tasks.findByName(PREPARE_SANDBOX_TASK_NAME)
+        project.tasks.withType(PrepareSandboxTask).each {
+            it.dependsOn(dependencySandboxTask)
+            it.configureCompositePlugin(pluginDependency)
         }
     }
 

--- a/src/test/groovy/org/jetbrains/intellij/PrepareSandboxTaskSpec.groovy
+++ b/src/test/groovy/org/jetbrains/intellij/PrepareSandboxTaskSpec.groovy
@@ -50,6 +50,53 @@ class PrepareSandboxTaskSpec extends IntelliJPluginSpecBase {
                                                         'META-INF/plugin.xml'] as Set
     }
 
+    def 'prepare sandbox for two plugins with evaluated project'() {
+        given:
+        writeJavaFile()
+        pluginXml << """\
+            <idea-plugin>
+              <id>org.intellij.test.plugin</id>
+              <name>Test Plugin</name>
+              <version>1.0</version>
+              <vendor url="https://jetbrains.com">JetBrains</vendor>
+              <description>test plugin</description>
+              <change-notes/>
+            </idea-plugin>""".stripIndent()
+
+        buildFile << """\
+            allprojects {
+                version='0.42.123'
+                apply plugin: 'org.jetbrains.intellij'
+                intellij { downloadSources = false }
+            }
+            project(':') {
+                intellij.pluginName = 'myPluginName'
+                intellij.plugins = [project(':nestedProject')]
+            }
+            project(':nestedProject') {
+                intellij.pluginName = 'myNestedPluginName'
+            }
+            """.stripIndent()
+        file('settings.gradle') << "include 'nestedProject'"
+        file('nestedProject/src/main/java/NestedAppFile.java') << "class NestedAppFile{}"
+        file('nestedProject/src/main/resources/META-INF/plugin.xml') << pluginXml.text
+
+        when:
+        build(":$IntelliJPlugin.PREPARE_SANDBOX_TASK_NAME")
+
+        then:
+        collectPaths(sandbox) == ['/plugins/myPluginName/lib/projectName-0.42.123.jar',
+                                  '/plugins/myNestedPluginName/lib/nestedProject-0.42.123.jar',
+                                  '/config/options/updates.xml'] as Set
+
+        def jar = new File(sandbox, '/plugins/myPluginName/lib/projectName-0.42.123.jar')
+        collectPaths(new ZipFile(jar)) == ['META-INF/', 'META-INF/MANIFEST.MF', 'App.class', 'META-INF/plugin.xml'] as Set
+
+        def nestedProjectJar = new File(sandbox, '/plugins/myNestedPluginName/lib/nestedProject-0.42.123.jar')
+        collectPaths(new ZipFile(nestedProjectJar)) == ['META-INF/', 'META-INF/MANIFEST.MF', 'NestedAppFile.class',
+                                                        'META-INF/plugin.xml'] as Set
+    }
+
     def 'prepare sandbox task without plugin_xml'() {
         given:
         writeJavaFile()


### PR DESCRIPTION
Gradle's project.afterEvaluate won't get executed if project is already
executed, so we have to check for this manually.