### PR TITLE
Modify patching node method

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/tasks/PatchPluginXmlTask.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/tasks/PatchPluginXmlTask.groovy
@@ -138,12 +138,6 @@ class PatchPluginXmlTask extends ConventionTask {
         files.each { file ->
             def pluginXml = Utils.parseXml(file)
 
-//            patchSinceUntilBuild(getSinceBuild(), getUntilBuild(), pluginXml)
-//            patchNode("description", getPluginDescription(), pluginXml)
-//            patchNode("change-notes", getChangeNotes(), pluginXml)
-//            patchPluginVersion(getVersion(), pluginXml)
-//            patchNode("id", getPluginId(), pluginXml)
-
             patchNode(pluginXml, "idea-version", [
                     "@since-build" : getSinceBuild(),
                     "@until-build" : getUntilBuild()])
@@ -171,41 +165,6 @@ class PatchPluginXmlTask extends ConventionTask {
             }
         }
     }
-
-//    static void patchPluginVersion(String pluginVersion, Node pluginXml) {
-//        if (pluginVersion && pluginVersion != Project.DEFAULT_VERSION) {
-//            def version = pluginXml.version
-//            if (version) {
-//                version*.value = pluginVersion
-//            } else {
-//                pluginXml.children().add(0, new Node(null, 'version', pluginVersion))
-//            }
-//        }
-//    }
-//
-//    static void patchSinceUntilBuild(String sinceBuild, String untilBuild, Node pluginXml) {
-//        if (sinceBuild && untilBuild) {
-//            def ideaVersionTag = pluginXml.'idea-version'
-//            if (ideaVersionTag) {
-//                ideaVersionTag*.'@since-build' = sinceBuild
-//                ideaVersionTag*.'@until-build' = untilBuild
-//            } else {
-//                pluginXml.children().add(0, new Node(null, 'idea-version',
-//                        ['since-build': sinceBuild, 'until-build': untilBuild]))
-//            }
-//        }
-//    }
-//
-//    static void patchNode(String name, String value, Node pluginXml) {
-//        if (value != null) {
-//            def tag = pluginXml."$name"
-//            if(tag) {
-//                tag*.value = value
-//            } else {
-//                pluginXml.children().add(0, new Node(null, name, value))
-//            }
-//        }
-//    }
 
     static void patchNode(Node pluginXml, String tagName, Map<String, Object> values) {
         if (!values) return

--- a/src/main/groovy/org/jetbrains/intellij/tasks/PatchPluginXmlTask.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/tasks/PatchPluginXmlTask.groovy
@@ -18,7 +18,6 @@ class PatchPluginXmlTask extends ConventionTask {
     private Object pluginId
 
     private static final String TAG_DATA = 'value'
-    private static final String TAG_NAME = "_tag-name_"
     private static final String BREAK_LOGIC = "_break-logic_"
 
     @OutputDirectory
@@ -139,23 +138,15 @@ class PatchPluginXmlTask extends ConventionTask {
         files.each { file ->
             def pluginXml = Utils.parseXml(file)
 
-            patchNode(pluginXml, [
-                    (TAG_NAME) : "idea-version",
+            patchNode(pluginXml, "idea-version",  [
                     "@since-build" : getSinceBuild(),
                     "@until-build" : getUntilBuild()])
-            patchNode(pluginXml, [
-                    (TAG_NAME) : "description",
-                    (TAG_DATA) : getPluginDescription()])
-            patchNode(pluginXml, [
-                    (TAG_NAME) : "change-notes",
-                    (TAG_DATA) : getChangeNotes()])
-            patchNode(pluginXml, [
-                    (TAG_NAME) : "version",
+            patchNode(pluginXml, "description", [(TAG_DATA) : getPluginDescription()])
+            patchNode(pluginXml, "change-notes", [(TAG_DATA) : getChangeNotes()])
+            patchNode(pluginXml, "version", [
                     (TAG_DATA) : getVersion(),
                     (BREAK_LOGIC) : getVersion() == Project.DEFAULT_VERSION])
-            patchNode(pluginXml, [
-                    (TAG_NAME) : "id",
-                    (TAG_DATA) : getPluginId()])
+            patchNode(pluginXml, "id", [(TAG_DATA) : getPluginId()])
 
             def writer
             try {
@@ -172,20 +163,16 @@ class PatchPluginXmlTask extends ConventionTask {
         }
     }
 
-    static void patchNode(Node pluginXml, Map<String, Object> values) {
-        def tagName
+    static void patchNode(Node pluginXml, String tagName, Map<String, Object> values) {
         if (!values) return
         if (values.remove(BREAK_LOGIC)) return
-        if (!(tagName = values.remove(TAG_NAME))) return
         values.each { it ->
             if (!it.value) return
             def tag = pluginXml."$tagName"
             if (tag) {
                 tag*."$it.key" = it.value
             } else {
-                def value = it.key.startsWith("@") \
-                        ? ([(it.key[1..-1]) : it.value])
-                        : (it.value)
+                def value = it.key.startsWith("@") ? [(it.key[1..-1]) : it.value] : it.value
                 pluginXml.children().add(0, new Node(null, tagName, value))
             }
         }

--- a/src/main/groovy/org/jetbrains/intellij/tasks/PatchPluginXmlTask.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/tasks/PatchPluginXmlTask.groovy
@@ -173,9 +173,10 @@ class PatchPluginXmlTask extends ConventionTask {
     }
 
     static void patchNode(Node pluginXml, Map<String, Object> values) {
-        if (!values || values.remove(BREAK_LOGIC)?.value) return
-        def tagName = values.remove(TAG_NAME)?.value?.toString()
-        if (!tagName) return
+        def tagName
+        if (!values) return
+        if (values.remove(BREAK_LOGIC)) return
+        if (!(tagName = values.remove(TAG_NAME))) return
         values.each { it ->
             if (!it.value) return
             def tag = pluginXml."$tagName"


### PR DESCRIPTION
# Pull Request
## Summary
I generalized the patching mechanism so that a single method will handle most use-cases (in fact, it will handle 100% of current use-cases) while allowing for easy extension of the plugin to allow patching of other XML elements in each `plugin.xml` file.

## Implementation
This patching mechanism is accomplished by passing a Typed-`Map` that contains all the information of a single XML element (plus optional `break` logic) such as the **tag name**, **tag attributes**, and **tag data**.

Also. these changes are invisible to users of this plugin.

## Comparison
### Previous Patching Mechanism
The previous patching mechanism is only available for 5 tags...
1. `idea-version`
 2. `description` 
 3. `change-notes`
 4. `version`
 5. `id`

### Current Pull Request Patch Mechanism
#### As Is
My current patching ability should allow you (JetBrains) to easily **add** the following 6 tags to the plugin capabilities...
 1. `name`
 2. `vendor` 
 3. `helpset`
 4. `resource-bundle`
 5. A single module dependency via `depends` 
    **OR**
 6. A single optional dependency via `depends optional="true"`).

I think 5 and 6 will only allow 1 total for both tags. Not 1 each; 1 total.

#### Slight Modification
With slight modifications, it should also be able to handle...
 1. `url` attribute for `idea-plugin` tag
 2. multiple `depends` tags

## Test Results
I only modified `PatchPluginXmlTask`, so I mostly only tested my modifications from `PatchPluginXmlSpec`
![patchpluginxmlspec_results](https://user-images.githubusercontent.com/8707125/31968638-b88e725c-b94c-11e7-82b7-b1b9747ac73b.PNG)

## Limitations
My current implementation (minus slight changes) cannot allow for patching nested tags (that I am aware of). 

The following cannot be patched with my implementation without a second patching mechanism...
 1. `application-components`
 2. `project-components`
 3. `module-components`
 4. `actions`
 5. `extensionPoints` 
 6. `extensions`