### PR TITLE
fix compatibility for SDK 182

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/tasks/IntelliJInstrumentCodeTask.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/tasks/IntelliJInstrumentCodeTask.groovy
@@ -60,7 +60,8 @@ class IntelliJInstrumentCodeTask extends ConventionTask {
                 getJavac2(),
                 "$ideaDependency.classes/lib/jdom.jar",
                 "$ideaDependency.classes/lib/asm-all.jar",
-                "$ideaDependency.classes/lib/jgoodies-forms.jar")
+                "$ideaDependency.classes/lib/jgoodies-forms.jar",
+                "$ideaDependency.classes/lib/forms-1.1-preview.jar")
 
         ant.taskdef(name: 'instrumentIdeaExtensions',
                 classpath: classpath.asPath,


### PR DESCRIPTION
In SDK 182, `jgoodies-forms.jar` has been renamed to `forms-1.1-preview.jar`.

![image](https://user-images.githubusercontent.com/2351748/41141885-4dba7fac-6b26-11e8-8c70-2309c4c72e15.png)


Relate issue: https://github.com/JetBrains/gradle-intellij-plugin/issues/290
