### PR TITLE
Update Kotlin

### DIFF
--- a/examples/kotlin-plugin/build.gradle
+++ b/examples/kotlin-plugin/build.gradle
@@ -1,12 +1,12 @@
 plugins {
-    id "org.jetbrains.kotlin.jvm" version '1.1.4'
+    id "org.jetbrains.kotlin.jvm" version '1.2.51'
 }
 
 repositories {
     mavenCentral()
 }
 
-ext.kotlin_version = '1.1.4'
+ext.kotlin_version = '1.2.51'
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testCompile 'junit:junit:4.11'


### PR DESCRIPTION
Let's use Kotlin 1.2.51, which is included into IJ 2018.2