### PR TITLE
Relax ivy artifact pattern

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/dependency/PluginDependencyManager.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/dependency/PluginDependencyManager.groovy
@@ -79,7 +79,7 @@ class PluginDependencyManager {
         project.repositories.ivy { repo ->
             repo.ivyPattern("$cacheDirectoryPath/[module]-[revision].[ext]") // ivy xml
             repo.artifactPattern("$ideaDependency.classes/plugins/[module]/[artifact].[ext]") // builtin plugins
-            repo.artifactPattern("$cacheDirectoryPath/[module]-[revision]/[artifact].[ext]") // external plugins
+            repo.artifactPattern("$cacheDirectoryPath/[module]-[revision]/[artifact](.[ext])") // external plugins
             pluginSources.each {
                 repo.artifactPattern("$it/[artifact].[ext]") // local plugins
             }

--- a/src/test/groovy/org/jetbrains/intellij/BuildPluginTaskSpec.groovy
+++ b/src/test/groovy/org/jetbrains/intellij/BuildPluginTaskSpec.groovy
@@ -145,6 +145,39 @@ class App {
         (new ZipFile(jar).entries().collect { it.name }).contains('App.class')
     }
 
+    def 'can compile classes that depend on external plugin with Gradle 4'() {
+        given:
+        file('src/main/java/App.java') << """
+import java.lang.String;
+import org.jetbrains.annotations.NotNull;
+import org.asciidoc.intellij.AsciiDoc;
+class App {
+    public static void main(@NotNull String[] strings) {
+        System.out.println(AsciiDoc.class.getName());
+    }
+}
+"""
+        pluginXml << '<idea-plugin version="2"></idea-plugin>'
+        buildFile << """\
+            version='0.42.123'
+            intellij {
+                version = '2018.2'
+                pluginName = 'myPluginName'
+                plugins = ['org.asciidoctor.intellij.asciidoc:0.20.6']
+                instrumentCode false
+            }
+            """.stripIndent()
+
+        when:
+        build("4.9", false, IntelliJPlugin.BUILD_PLUGIN_TASK_NAME)
+
+        then:
+        File distribution = new File(buildDirectory, 'distributions/myPluginName-0.42.123.zip')
+        distribution.exists()
+        def jar = extractFile(new ZipFile(distribution), 'myPluginName/lib/projectName-0.42.123.jar')
+        (new ZipFile(jar).entries().collect { it.name }).contains('App.class')
+    }
+
     def 'build plugin without sources'() {
         given:
         pluginXml << '<idea-plugin version="2"></idea-plugin>'


### PR DESCRIPTION
Using this plugin with Gradle 4.9 to build a project
that included the AsciiDoctor IDEA plugin was failing
due to Gradle being unable to find AsciiDoctor's
classes directory. Relaxing the pattern to make the
extension part (particularly the period preceding it)
optional fixes the issue.

Signed-off-by: Eddie Ringle <eddie@ringle.io>