### PR TITLE
Properly resolve tools.jar for OSX

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/Utils.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/Utils.groovy
@@ -235,6 +235,15 @@ class Utils {
         }, recursively ? TrueFileFilter.INSTANCE : FalseFileFilter.FALSE)
     }
 
+    static String resolveToolsJar(String javaExec) {
+        String binDir = new File(javaExec).parent
+        if (OperatingSystem.current().isMacOsX()) {
+            return "$binDir/../../lib/tools.jar"
+        }
+        return "$binDir/../lib/tools.jar"
+    }
+
+
     static String getBuiltinJbreVersion(@NotNull File ideaDirectory) {
         def dependenciesFile = new File(ideaDirectory, "dependencies.txt")
         if (dependenciesFile.exists()) {

--- a/src/main/groovy/org/jetbrains/intellij/Utils.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/Utils.groovy
@@ -243,7 +243,6 @@ class Utils {
         return "$binDir/../lib/tools.jar"
     }
 
-
     static String getBuiltinJbreVersion(@NotNull File ideaDirectory) {
         def dependenciesFile = new File(ideaDirectory, "dependencies.txt")
         if (dependenciesFile.exists()) {

--- a/src/main/groovy/org/jetbrains/intellij/tasks/RunIdeTask.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/tasks/RunIdeTask.groovy
@@ -1,14 +1,10 @@
 package org.jetbrains.intellij.tasks
 
-import org.gradle.api.GradleException
+
 import org.gradle.api.tasks.*
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.util.CollectionUtils
 import org.jetbrains.intellij.Utils
-
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
 
 class RunIdeTask extends JavaExec {
     private static final def PREFIXES = [IU: null,
@@ -133,7 +129,7 @@ class RunIdeTask extends JavaExec {
     private void configureClasspath() {
         File ideaDirectory = getIdeaDirectory()
         def executable = getExecutable()
-        if (executable) classpath += project.files(resolveToolsJar(executable))
+        if (executable) classpath += project.files(Utils.resolveToolsJar(executable))
         classpath += project.files("$ideaDirectory/lib/idea_rt.jar",
                 "$ideaDirectory/lib/idea.jar",
                 "$ideaDirectory/lib/bootstrap.jar",
@@ -143,23 +139,6 @@ class RunIdeTask extends JavaExec {
                 "$ideaDirectory/lib/trove4j.jar",
                 "$ideaDirectory/lib/jdom.jar",
                 "$ideaDirectory/lib/log4j.jar")
-    }
-
-    private String resolveToolsJar(String javaExec) {
-        String binDir = new File(javaExec).parent
-        // tools.jar for windows & linux
-        // sibling of bin dir
-        Path toolsJar = Paths.get("$binDir/../lib/tools.jar")
-        // tools.jar for osx
-        // sibling of the parent of bind dir
-        Path altToolsJar = Paths.get("$binDir/../../lib/tools.jar")
-        if (Files.exists(toolsJar)) {
-            return toolsJar.toString()
-        } else if (Files.exists(altToolsJar)) {
-            return altToolsJar.toString()
-        }
-
-        throw new GradleException("Unable to resolve tools.jar for $javaExec.")
     }
 
     def configureSystemProperties() {

--- a/src/main/groovy/org/jetbrains/intellij/tasks/RunIdeTask.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/tasks/RunIdeTask.groovy
@@ -1,10 +1,14 @@
 package org.jetbrains.intellij.tasks
 
+import org.gradle.api.GradleException
 import org.gradle.api.tasks.*
-import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.util.CollectionUtils
 import org.jetbrains.intellij.Utils
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 
 class RunIdeTask extends JavaExec {
     private static final def PREFIXES = [IU: null,
@@ -129,7 +133,7 @@ class RunIdeTask extends JavaExec {
     private void configureClasspath() {
         File ideaDirectory = getIdeaDirectory()
         def executable = getExecutable()
-        if (executable) classpath += project.files("${new File(executable).parent}/../lib/tools.jar")
+        if (executable) classpath += project.files(resolveToolsJar(executable))
         classpath += project.files("$ideaDirectory/lib/idea_rt.jar",
                 "$ideaDirectory/lib/idea.jar",
                 "$ideaDirectory/lib/bootstrap.jar",
@@ -139,6 +143,23 @@ class RunIdeTask extends JavaExec {
                 "$ideaDirectory/lib/trove4j.jar",
                 "$ideaDirectory/lib/jdom.jar",
                 "$ideaDirectory/lib/log4j.jar")
+    }
+
+    private String resolveToolsJar(String javaExec) {
+        String binDir = new File(javaExec).parent
+        // tools.jar for windows & linux
+        // sibling of bin dir
+        Path toolsJar = Paths.get("$binDir/../lib/tools.jar")
+        // tools.jar for osx
+        // sibling of the parent of bind dir
+        Path altToolsJar = Paths.get("$binDir/../../lib/tools.jar")
+        if (Files.exists(toolsJar)) {
+            return toolsJar.toString()
+        } else if (Files.exists(altToolsJar)) {
+            return altToolsJar.toString()
+        }
+
+        throw new GradleException("Unable to resolve tools.jar for $javaExec.")
     }
 
     def configureSystemProperties() {


### PR DESCRIPTION
Dir layout for linux and windows:

```
base/
  - bin/ <- java executable located here
  - lib/ <- tools.jar located here
```

Dir layout for osx:
```
base/
  - jre/
    - bin/  <- java executable located here
    - lib/
  - lib/ <- tools.jar located here
```

Resolves #312.

@scana can you check if the above layout holds true? 