### PR TITLE
Fix markerFile logic

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/dependency/IdeaDependencyManager.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/dependency/IdeaDependencyManager.groovy
@@ -204,8 +204,9 @@ class IdeaDependencyManager {
         return Utils.unzip(zipFile, cacheDirectory, project, {
             markerFile -> isCacheUpToDate(zipFile, markerFile, checkVersionChange)
         }, { markerFile ->
-            resetExecutablePermissions(cacheDirectory, type)
-            storeCache(cacheDirectory, markerFile)
+            def targetDirectory = markerFile.parentFile
+            resetExecutablePermissions(targetDirectory, type)
+            storeCache(targetDirectory, markerFile)
         })
     }
 


### PR DESCRIPTION
We were looking for build.txt inside parent of unzipped dir, didn't
find it there, and didn't write anything into markerFile. As a result
same file was unzipped many times.