### PR TITLE
Make intellij.publish Kotlin DSL-friendly

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPluginExtension.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPluginExtension.groovy
@@ -1,5 +1,6 @@
 package org.jetbrains.intellij
 
+import org.gradle.api.Action
 import org.jetbrains.intellij.dependency.IdeaDependency
 import org.jetbrains.intellij.dependency.PluginDependency
 
@@ -71,6 +72,10 @@ class IntelliJPluginExtension {
 
     def publish(Closure c) {
         publish.with(c)
+    }
+
+    void publish(Action<Publish> action) {
+        action.execute(publish)
     }
 
     /**


### PR DESCRIPTION
With the Gradle Kotlin DSL, you currently have to write

    intellij {
        publish(closureOf<IntelliJPluginExtension.Publish> {
            user = "..."
            ...
        }
    }

By overloading publish with an `Action` argument, you can now write

    intellij {
        publish {
            user = "..."
            ...
        }
    }