### PR TITLE
Override Rider SDK cache directory on Windows only

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/dependency/IdeaDependencyManager.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/dependency/IdeaDependencyManager.groovy
@@ -144,7 +144,7 @@ class IdeaDependencyManager {
             if (customCacheParent.exists()) {
                 return new File(customCacheParent.absolutePath)
             }
-        } else if (type == 'RD') {
+        } else if (type == 'RD' && OperatingSystem.current().isWindows()) {
             return project.buildDir
         }
         return zipFile.parentFile


### PR DESCRIPTION
Rider SDK cache directory is being overridden to prevent long path exceptions on Windows. However, there's no point to override it on macOS and Linux.
Reusing Gradle caches, the default behaviour, helps when having multiple working copies or plugins using the SDK.