### PR TITLE
Typo fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Plugin provides following options to configure target IntelliJ SDK and build arc
 
 ### Setup DSL
 
-The following attributes are apart of the Setup DSL <kbd>intellij { ... }</kbd> in which allows you to setup the environment and dependencies.
+The following attributes are part of the Setup DSL <kbd>intellij { ... }</kbd> in which allows you to setup the environment and dependencies.
 
 | **Attributes** | **Values** | 
 | :------------- | :--------- | 

--- a/src/docs/configuration.md.templar
+++ b/src/docs/configuration.md.templar
@@ -6,7 +6,7 @@ Plugin provides following options to configure target IntelliJ SDK and build arc
 
 ### Setup DSL
 
-The following attributes are apart of the Setup DSL <kbd>intellij { ... }</kbd> in which allows you to setup the environment and dependencies.
+The following attributes are part of the Setup DSL <kbd>intellij { ... }</kbd> in which allows you to setup the environment and dependencies.
 
 pre}
 {\n}


### PR DESCRIPTION
Fix typo by replacing `apart` with `part`. Otherwise, sense of `The following attributes are _apart_ of the Setup DSL...` is completely opposite of what it should be (?).