### PR TITLE
Remove gcloud plugin repo from list of examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ As examples of using this plugin you can check out following projects:
 - [AceJump plugin](https://github.com/johnlindquist/AceJump)  
 	- Uses the Gradle Kotlin DSL
 - [EmberJS plugin](https://github.com/Turbo87/intellij-emberjs)
-- [GCloud plugin](https://github.com/GoogleCloudPlatform/gcloud-intellij)
 - [HCL plugin](https://github.com/VladRassokhin/intellij-hcl)
 - [Robot plugin](https://github.com/AmailP/robot-plugin)
 - [TOML plugin](https://github.com/stuartcarnie/toml-plugin)


### PR DESCRIPTION
The gcloud plugin repo is now just for docs and issues.