### PR TITLE
Possibility to turn off building searchable options

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
@@ -335,7 +335,7 @@ class IntelliJPlugin implements Plugin<Project> {
             task.dependsOn(PREPARE_SANDBOX_TASK_NAME)
             task.onlyIf {
                 def number = Utils.ideaBuildNumber(Utils.ideaSdkDirectory(extension))
-                VersionNumber.parse(number[number.indexOf('-') + 1..-1]) >= VersionNumber.parse("191.2752")
+                VersionNumber.parse(number[number.indexOf('-') + 1..-1]) >= VersionNumber.parse("191.2752") && extension.buildSearchableOptions
             }
         }
     }

--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPluginExtension.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPluginExtension.groovy
@@ -20,6 +20,7 @@ class IntelliJPluginExtension {
     String alternativeIdePath
     String ideaDependencyCachePath
     boolean instrumentCode = true
+    boolean buildSearchableOptions = true
     boolean updateSinceUntilBuild = true
     boolean sameSinceUntilBuild = false
     boolean downloadSources = true


### PR DESCRIPTION
If I know my plugin does not contain any configurables, I can speed
up its build by turning off the searchable options builder.