### PR TITLE
Gradle 6.0.1 support. Update gradle-download-task. 4.0.0 -> 4.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compile 'org.jetbrains.intellij:plugin-repository-rest-client:0.6.3'
     compile 'org.jetbrains.intellij.plugins:structure-base:3.46'
     compile 'org.jetbrains.intellij.plugins:structure-intellij:3.46'
-    compile 'de.undercouch:gradle-download-task:4.0.0'
+    compile 'de.undercouch:gradle-download-task:4.0.2'
 
     testCompile gradleTestKit()
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4', {


### PR DESCRIPTION
Details - https://github.com/michel-kraemer/gradle-download-task/issues/143
Otherwise loading process will be unavailable in Gradle 6.0.1