### PR TITLE
Add prepareTestingSandbox as an input to tests

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
@@ -619,7 +619,7 @@ class IntelliJPlugin implements Plugin<Project> {
             task.outputs.dir(configDirectory)
 
             PrepareSandboxTask prepareTestingSandboxTask = project.getTasksByName(PREPARE_TESTING_SANDBOX_TASK_NAME, false).find() as PrepareSandboxTask
-            task.dependsOn(prepareTestingSandboxTask)
+            task.inputs.files(prepareTestingSandboxTask)
 
             task.doFirst {
                 task.jvmArgs = Utils.getIdeJvmArgs(task, task.jvmArgs, Utils.ideSdkDirectory(project, extension))


### PR DESCRIPTION
This ensures that tests are out-of-date when the contents
of the test sandbox change.

Fixes #541