### PR TITLE
Don't fail on usage of java plugin id instead of plain `java`

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
@@ -282,7 +282,8 @@ class IntelliJPlugin implements Plugin<Project> {
     }
 
     private static void verifyJavaPluginDependency(IntelliJPluginExtension extension, Project project) {
-        if (!extension.plugins.contains('java') && new File(extension.ideaDependency.classes, "plugins/java").exists()) {
+        def hasJavaPluginDependency = extension.plugins.contains('java') || extension.plugins.contains('com.intellij.java')
+        if (!hasJavaPluginDependency && new File(extension.ideaDependency.classes, "plugins/java").exists()) {
             Utils.sourcePluginXmlFiles(project).each { file ->
                 def pluginXml = Utils.parseXml(file)
                 if (pluginXml) {


### PR DESCRIPTION
Fixes #565