### PR TITLE
Kotlin utils

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
         exclude(group = "org.jetbrains.kotlin")
     }
     implementation("de.undercouch:gradle-download-task:4.0.4")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.1")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.1")
 
     testImplementation(gradleTestKit())
     testImplementation("org.spockframework:spock-core:1.0-groovy-2.4") {

--- a/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/IntelliJPlugin.groovy
@@ -244,7 +244,7 @@ class IntelliJPlugin implements Plugin<Project> {
                 if (it instanceof Project) {
                     configureProjectPluginDependency(project, it, dependencies, extension)
                 } else {
-                    def pluginDependency = Utils.parsePluginDependencyString(it.toString())
+                    def pluginDependency = PluginDependencyNotation.parsePluginDependencyString(it.toString())
                     if (pluginDependency.id == null) {
                         throw new BuildException("Failed to resolve plugin $it", null)
                     }
@@ -473,7 +473,7 @@ class IntelliJPlugin implements Plugin<Project> {
             task.outputs.dir("$project.buildDir/$SEARCHABLE_OPTIONS_DIR_NAME")
             task.dependsOn(PREPARE_SANDBOX_TASK_NAME)
             task.onlyIf {
-                def number = Utils.ideBuildNumber(Utils.ideSdkDirectory(project, extension))
+                def number = Utils.ideBuildNumber(Utils.ideSdkDirectory(project, extension.alternativeIdePath, extension.ideaDependency.classes))
                 VersionNumber.parse(number[number.indexOf('-') + 1..-1]) >= VersionNumber.parse("191.2752")
             }
         }
@@ -482,7 +482,7 @@ class IntelliJPlugin implements Plugin<Project> {
     private static void prepareConventionMappingsForRunIdeTask(@NotNull Project project, @NotNull IntelliJPluginExtension extension,
                                                                @NotNull RunIdeBase task, @NotNull String prepareSandBoxTaskName) {
         def prepareSandboxTask = project.tasks.findByName(prepareSandBoxTaskName) as PrepareSandboxTask
-        task.conventionMapping("ideDirectory", { Utils.ideSdkDirectory(project, extension) })
+        task.conventionMapping("ideDirectory", { Utils.ideSdkDirectory(project, extension.alternativeIdePath, extension.ideaDependency.classes) })
         task.conventionMapping("requiredPluginIds", { Utils.getPluginIds(project) })
         task.conventionMapping("configDirectory", { project.file(prepareSandboxTask.getConfigDirectory()) })
         task.conventionMapping("pluginsDirectory", { prepareSandboxTask.getDestinationDir() })
@@ -490,7 +490,7 @@ class IntelliJPlugin implements Plugin<Project> {
             project.file("${extension.sandboxDirectory}/system")
         })
         task.conventionMapping("autoReloadPlugins", {
-            def number = Utils.ideBuildNumber(Utils.ideSdkDirectory(project, extension))
+            def number = Utils.ideBuildNumber(Utils.ideSdkDirectory(project, extension.alternativeIdePath, extension.ideaDependency.classes))
             VersionNumber.parse(number[number.indexOf('-') + 1..-1]) >= VersionNumber.parse("202.0")
         })
         task.conventionMapping("executable", {
@@ -503,7 +503,7 @@ class IntelliJPlugin implements Plugin<Project> {
                 }
                 Utils.warn(task, "Cannot resolve JBR $jbrVersion. Falling back to builtin JBR.")
             }
-            def builtinJbrVersion = Utils.getBuiltinJbrVersion(Utils.ideSdkDirectory(project, extension))
+            def builtinJbrVersion = Utils.getBuiltinJbrVersion(Utils.ideSdkDirectory(project, extension.alternativeIdePath, extension.ideaDependency.classes))
             if (builtinJbrVersion != null) {
                 def builtinJbr = jbrResolver.resolve(builtinJbrVersion)
                 if (builtinJbr != null) {
@@ -624,7 +624,7 @@ class IntelliJPlugin implements Plugin<Project> {
             task.inputs.files(prepareTestingSandboxTask)
 
             task.doFirst {
-                task.jvmArgs = Utils.getIdeJvmArgs(task, task.jvmArgs, Utils.ideSdkDirectory(project, extension))
+                task.jvmArgs = Utils.getIdeJvmArgs(task, task.jvmArgs, Utils.ideSdkDirectory(project, extension.alternativeIdePath, extension.ideaDependency.classes))
                 task.classpath += project.files(
                         "$extension.ideaDependency.classes/lib/resources.jar",
                         "$extension.ideaDependency.classes/lib/idea.jar"

--- a/src/main/groovy/org/jetbrains/intellij/dependency/IdeaDependencyManager.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/dependency/IdeaDependencyManager.groovy
@@ -221,7 +221,7 @@ class IdeaDependencyManager {
         }, { unzippedDirectory, markerFile ->
             resetExecutablePermissions(project, unzippedDirectory, type)
             storeCache(unzippedDirectory, markerFile)
-        })
+        }, null)
     }
 
     private static boolean isCacheUpToDate(File zipFile, File markerFile, boolean checkVersion) {
@@ -287,7 +287,7 @@ class IdeaDependencyManager {
             generator.addConfiguration(new DefaultIvyConfiguration("compile"))
             generator.addConfiguration(new DefaultIvyConfiguration("sources"))
             dependency.jarFiles.each {
-                generator.addArtifact(Utils.createJarDependency(it, "compile", dependency.classes))
+                generator.addArtifact(IntellijIvyArtifact.createJarDependency(it, "compile", dependency.classes))
             }
             if (dependency.sources) {
                 def artifact = new IntellijIvyArtifact(dependency.sources, 'ideaIC', "jar", "sources", "sources")

--- a/src/main/groovy/org/jetbrains/intellij/dependency/IntellijIvyArtifact.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/dependency/IntellijIvyArtifact.groovy
@@ -3,6 +3,7 @@ package org.jetbrains.intellij.dependency
 import org.gradle.api.internal.tasks.DefaultTaskDependency
 import org.gradle.api.publish.ivy.IvyArtifact
 import org.gradle.api.tasks.TaskDependency
+import org.jetbrains.annotations.NotNull
 
 class IntellijIvyArtifact implements IvyArtifact {
     private final DefaultTaskDependency buildDependencies = new DefaultTaskDependency()
@@ -76,5 +77,23 @@ class IntellijIvyArtifact implements IvyArtifact {
     @Override
     String toString() {
         return String.format("%s %s:%s:%s:%s", getClass().getSimpleName(), getName(), getType(), getExtension(), getClassifier())
+    }
+
+    @NotNull
+    static IvyArtifact createJarDependency(File file, String configuration, File baseDir, String classifier = null) {
+        return createDependency(baseDir, file, configuration, "jar", "jar", classifier)
+    }
+
+    @NotNull
+    static IvyArtifact createDirectoryDependency(File file, String configuration, File baseDir, String classifier = null) {
+        return createDependency(baseDir, file, configuration, "", "directory", classifier)
+    }
+
+    private static IvyArtifact createDependency(File baseDir, File file, String configuration, String extension, String type, String classifier) {
+        def relativePath = baseDir.toURI().relativize(file.toURI()).getPath()
+        def name = extension ? relativePath - ".$extension" : relativePath
+        def artifact = new IntellijIvyArtifact(file, name, extension, type, classifier)
+        artifact.conf = configuration
+        return artifact
     }
 }

--- a/src/main/groovy/org/jetbrains/intellij/dependency/PluginDependencyManager.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/dependency/PluginDependencyManager.groovy
@@ -133,13 +133,13 @@ class PluginDependencyManager {
             generator.addConfiguration(new DefaultIvyConfiguration("sources"))
             generator.addConfiguration(new DefaultIvyConfiguration("default"))
             plugin.jarFiles.each {
-                generator.addArtifact(Utils.createJarDependency(it, configuration.name, baseDir, groupId))
+                generator.addArtifact(IntellijIvyArtifact.createJarDependency(it, configuration.name, baseDir, groupId))
             }
             if (plugin.classesDirectory) {
-                generator.addArtifact(Utils.createDirectoryDependency(plugin.classesDirectory, configuration.name, baseDir, groupId))
+                generator.addArtifact(IntellijIvyArtifact.createDirectoryDependency(plugin.classesDirectory, configuration.name, baseDir, groupId))
             }
             if (plugin.metaInfDirectory) {
-                generator.addArtifact(Utils.createDirectoryDependency(plugin.metaInfDirectory, configuration.name, baseDir, groupId))
+                generator.addArtifact(IntellijIvyArtifact.createDirectoryDependency(plugin.metaInfDirectory, configuration.name, baseDir, groupId))
             }
             if (plugin.builtin && ideaDependency.sources) {
                 def artifact = new IntellijIvyArtifact(ideaDependency.sources, "ideaIC", "jar", "sources", "sources")

--- a/src/main/groovy/org/jetbrains/intellij/dependency/PluginDependencyNotation.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/dependency/PluginDependencyNotation.groovy
@@ -53,4 +53,37 @@ class PluginDependencyNotation {
         result = 31 * result + (channel != null ? channel.hashCode() : 0)
         return result
     }
+
+    @NotNull
+    static PluginDependencyNotation parsePluginDependencyString(@NotNull String s) {
+        if (new File(s).exists()) {
+            return new PluginDependencyNotation(s, null, null)
+        }
+
+        String id = null, version = null, channel = null
+        def idAndVersion = s.split('[:]', 2)
+        if (idAndVersion.length == 1) {
+            def idAndChannel = idAndVersion[0].split('[@]', 2)
+            id = idAndChannel[0]
+            channel = idAndChannel.length > 1 ? idAndChannel[1] : null
+        } else if (idAndVersion.length == 2) {
+            def versionAndChannel = idAndVersion[1].split('[@]', 2)
+            id = idAndVersion[0]
+            version = versionAndChannel[0]
+            channel = versionAndChannel.length > 1 ? versionAndChannel[1] : null
+        }
+        return new PluginDependencyNotation(id ?: null, version ?: null, channel ?: null)
+    }
+
+// TODO: Replace with the following Kotlin snippet
+//
+//    fun parsePluginDependencyString(s: String): PluginDependencyNotation {
+//        if (File(s).exists()) {
+//            return PluginDependencyNotation(s, null, null)
+//        }
+//
+//        val (idVersion, channel) = s.split('@', limit = 2) + null
+//        val (id, version) = (idVersion ?: s).split(':', limit = 2) + null
+//        return PluginDependencyNotation(id ?: s, version, channel)
+//    }
 }

--- a/src/main/groovy/org/jetbrains/intellij/tasks/RunPluginVerifierTask.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/tasks/RunPluginVerifierTask.groovy
@@ -766,7 +766,7 @@ class RunPluginVerifierTask extends ConventionTask {
         def extension = project.extensions.findByType(IntelliJPluginExtension)
         def jbrPath = OperatingSystem.current().isMacOsX() ? "jbr/Contents/Home" : "jbr"
 
-        def builtinJbrVersion = Utils.getBuiltinJbrVersion(Utils.ideSdkDirectory(project, extension))
+        def builtinJbrVersion = Utils.getBuiltinJbrVersion(Utils.ideSdkDirectory(project, extension.alternativeIdePath, extension.ideaDependency.classes))
         if (builtinJbrVersion != null) {
             def builtinJbr = jbrResolver.resolve(builtinJbrVersion)
             if (builtinJbr != null) {

--- a/src/main/kotlin/org/jetbrains/intellij/PluginXml.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/PluginXml.kt
@@ -1,0 +1,10 @@
+package org.jetbrains.intellij
+
+import com.fasterxml.jackson.annotation.JsonRootName
+
+@JsonRootName("idea-plugin")
+data class PluginXml(
+    var name: String? = null,
+    var id: String? = null,
+    var vendor: String? = null,
+)

--- a/src/main/kotlin/org/jetbrains/intellij/utils.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/utils.kt
@@ -1,11 +1,20 @@
+@file:JvmName("Utils")
+
 package org.jetbrains.intellij
 
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationFail
 import com.jetbrains.plugin.structure.base.plugin.PluginCreationSuccess
 import com.jetbrains.plugin.structure.base.plugin.PluginProblem
-import com.jetbrains.plugin.structure.base.utils.FileUtilKt
+import com.jetbrains.plugin.structure.base.utils.isJar
+import com.jetbrains.plugin.structure.base.utils.isZip
 import com.jetbrains.plugin.structure.intellij.plugin.IdePlugin
 import com.jetbrains.plugin.structure.intellij.plugin.IdePluginManager
+import groovy.lang.Closure
+import groovy.util.Node
+import groovy.util.XmlParser
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.filefilter.AbstractFileFilter
 import org.apache.commons.io.filefilter.FalseFileFilter
@@ -13,355 +22,288 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.Logging
 import org.gradle.api.plugins.JavaPluginConvention
-import org.gradle.api.publish.ivy.IvyArtifact
 import org.gradle.api.tasks.SourceSet
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.process.JavaForkOptions
-import org.gradle.util.CollectionUtils
-import org.jetbrains.annotations.NotNull
-import org.jetbrains.annotations.Nullable
-import org.jetbrains.intellij.dependency.IntellijIvyArtifact
-import org.jetbrains.intellij.dependency.PluginDependencyNotation
 import org.xml.sax.ErrorHandler
 import org.xml.sax.InputSource
-import org.xml.sax.SAXException
 import org.xml.sax.SAXParseException
-
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileReader
+import java.io.IOException
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.util.Properties
 import java.util.function.BiConsumer
 import java.util.function.Predicate
-import java.util.regex.Pattern
 
-class Utils {
-    public static final Pattern VERSION_PATTERN = Pattern.compile('^([A-Z]+)-([0-9.A-z]+)\\s*$')
+val VERSION_PATTERN = "^([A-Z]+)-([0-9.A-z]+)\\s*$".toPattern()
+val MAJOR_VERSION_PATTERN = "(RIDER-)?\\d{4}\\.\\d-SNAPSHOT".toPattern()
 
-    @NotNull
-    static SourceSet mainSourceSet(@NotNull Project project) {
-        JavaPluginConvention javaConvention = project.convention.getPlugin(JavaPluginConvention)
-        javaConvention.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-    }
+fun mainSourceSet(project: Project): SourceSet {
+    val javaConvention = project.convention.getPlugin(JavaPluginConvention::class.java)
+    return javaConvention.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+}
 
-    @NotNull
-    static IvyArtifact createjardependency(File file, String configuration, File baseDir, String classifier = null) {
-        return createDependency(baseDir, file, configuration, "jar", "jar", classifier)
-    }
-
-    @NotNull
-    static IvyArtifact createDirectoryDependency(File file, String configuration, File baseDir, String classifier = null) {
-        return createDependency(baseDir, file, configuration, "", "directory", classifier)
-    }
-
-    private static IvyArtifact createDependency(File baseDir, File file, String configuration, String extension, String type, String classifier) {
-        def relativePath = baseDir.toURI().relativize(file.toURI()).getPath()
-        def name = extension ? relativePath - ".$extension" : relativePath
-        def artifact = new IntellijIvyArtifact(file, name, extension, type, classifier)
-        artifact.conf = configuration
-        return artifact
-    }
-
-    @NotNull
-    static FileCollection sourcePluginXmlFiles(@NotNull Project project) {
-        Set<File> result = new HashSet<>()
-        mainSourceSet(project).resources.srcDirs.each {
-            def pluginXml = new File(it, "META-INF/plugin.xml")
-            if (pluginXml.exists()) {
-                try {
-                    if (parseXml(pluginXml).name() == 'idea-plugin') {
-                        result += pluginXml
-                    }
-                } catch (SAXParseException e) {
-                    warn(project, "Cannot read ${pluginXml}. Skipping", e)
-                }
-            }
-        }
-        project.files(result)
-    }
-
-    @NotNull
-    static Map<String, Object> getIdeaSystemProperties(@NotNull File configDirectory,
-                                                       @NotNull File systemDirectory,
-                                                       @NotNull File pluginsDirectory,
-                                                       @NotNull List<String> requirePluginIds) {
-        def result = ["idea.config.path" : configDirectory.absolutePath,
-                      "idea.system.path" : systemDirectory.absolutePath,
-                      "idea.plugins.path": pluginsDirectory.absolutePath]
-        if (!requirePluginIds.empty) {
-            result.put("idea.required.plugins.id", requirePluginIds.join(","))
-        }
-        result
-    }
-
-    @NotNull
-    static List<String> getIdeJvmArgs(@NotNull JavaForkOptions options,
-                                      @NotNull List<String> originalArguments,
-                                      @NotNull File ideDirectory) {
-        if (options.maxHeapSize == null) options.maxHeapSize = "512m"
-        if (options.minHeapSize == null) options.minHeapSize = "256m"
-        List<String> result = new ArrayList<String>(originalArguments)
-        def bootJar = new File(ideDirectory, "lib/boot.jar")
-        if (bootJar.exists()) result.add("-Xbootclasspath/a:$bootJar.absolutePath")
-        return result
-    }
-
-    @NotNull
-    static File ideSdkDirectory(@NotNull Project project, @NotNull IntelliJPluginExtension extension) {
-        def path = extension.alternativeIdePath
-        if (path) {
-            def dir = ideaDir(path)
-            if (!dir.exists()) {
-                def ideDirectory = extension.ideaDependency.classes
-                error(project, "Cannot find alternate SDK path: $dir. Default IDE will be used : $ideDirectory")
-                return ideDirectory
-            }
-            return dir
-        }
-        return extension.ideaDependency.classes
-    }
-
-    @NotNull
-    static String ideBuildNumber(@NotNull File ideDirectory) {
-        if (OperatingSystem.current().isMacOsX()) {
-            def file = new File(ideDirectory, "Resources/build.txt")
-            if (file.exists()) {
-                return file.getText('UTF-8').trim()
-            }
-        }
-        return new File(ideDirectory, "build.txt").getText('UTF-8').trim()
-    }
-
-    @NotNull
-    static File ideaDir(@NotNull String path) {
-        File dir = new File(path)
-        return dir.name.endsWith(".app") ? new File(dir, "Contents") : dir
-    }
-
-    // todo: collect all ids for multi-project configuration
-    static List<String> getPluginIds(@NotNull Project project) {
-        Set<String> ids = new HashSet<>()
-        sourcePluginXmlFiles(project).files.each {
-            def pluginXml = parseXml(it)
-            ids += pluginXml.id*.text()
-        }
-        return ids.size() == 1 ? [ids.first()] : Collections.<String> emptyList()
-    }
-
-    static Node parseXml(File file) {
-        return parseXml(new FileInputStream(file))
-    }
-
-    static Node parseXml(InputStream inputStream) {
-        def parser = new XmlParser(false, true, true)
-        parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
-        parser.setErrorHandler(new ErrorHandler() {
-            @Override
-            void warning(SAXParseException e) throws SAXException {
-
-            }
-
-            @Override
-            void error(SAXParseException e) throws SAXException {
-                throw e
-            }
-
-            @Override
-            void fatalError(SAXParseException e) throws SAXException {
-                throw e
-            }
-        })
-        InputSource input = new InputSource(new InputStreamReader(inputStream, "UTF-8"))
-        input.setEncoding("UTF-8")
-        try {
-            return parser.parse(input)
-        }
-        finally {
-            inputStream.close()
-        }
-    }
-
-    static boolean isJarFile(@NotNull File file) {
-        return FileUtilKt.isJar(file.toPath())
-    }
-
-    static boolean isZipFile(@NotNull File file) {
-        return FileUtilKt.isZip(file.toPath())
-    }
-
-    @NotNull
-    static PluginDependencyNotation parsePluginDependencyString(@NotNull String s) {
-        if (new File(s).exists()) {
-            return new PluginDependencyNotation(s, null, null)
-        }
-
-        def id = null, version = null, channel = null
-        def idAndVersion = s.split('[:]', 2)
-        if (idAndVersion.length == 1) {
-            def idAndChannel = idAndVersion[0].split('[@]', 2)
-            id = idAndChannel[0]
-            channel = idAndChannel.length > 1 ? idAndChannel[1] : null
-        } else if (idAndVersion.length == 2) {
-            def versionAndChannel = idAndVersion[1].split('[@]', 2)
-            id = idAndVersion[0]
-            version = versionAndChannel[0]
-            channel = versionAndChannel.length > 1 ? versionAndChannel[1] : null
-        }
-        return new PluginDependencyNotation(id ?: null, version ?: null, channel ?: null)
-    }
-
-    static String stringInput(input) {
-        input = input instanceof Closure ? (input as Closure).call() : input
-        return input?.toString()
-    }
-
-    static List<String> stringListInput(input) {
-        return CollectionUtils.stringize(input.collect {
-            it instanceof Closure ? (it as Closure).call() : it
-        }.flatten())
-    }
-
-    @NotNull
-    static Collection<File> collectJars(@NotNull File directory, @NotNull final Predicate<File> filter) {
-        return FileUtils.listFiles(directory, new AbstractFileFilter() {
-            @Override
-            boolean accept(File file) {
-                return isJarFile(file) && filter.test(file)
-            }
-        }, FalseFileFilter.FALSE)
-    }
-
-    static String resolveToolsJar(String javaExec) {
-        String binDir = new File(javaExec).parent
-        if (OperatingSystem.current().isMacOsX()) {
-            return "$binDir/../../lib/tools.jar"
-        }
-        return "$binDir/../lib/tools.jar"
-    }
-
-    static String getBuiltinJbrVersion(@NotNull File ideDirectory) {
-        def dependenciesFile = new File(ideDirectory, "dependencies.txt")
-        if (dependenciesFile.exists()) {
-            def properties = new Properties()
-            def reader = new FileReader(dependenciesFile)
+fun sourcePluginXmlFiles(project: Project): FileCollection {
+    val result = HashSet<File>()
+    mainSourceSet(project).resources.srcDirs.forEach {
+        val pluginXml = File(it, "META-INF/plugin.xml")
+        if (pluginXml.exists()) {
             try {
-                properties.load(reader)
-                return properties.getProperty('jdkBuild')
-            }
-            catch (IOException ignore) {
-            }
-            finally {
-                reader.close()
+                if (parseXml(pluginXml).name() == "idea-plugin") {
+                    result += pluginXml
+                }
+            } catch (e: SAXParseException) {
+                warn(project, "Cannot read ${pluginXml}. Skipping", e)
             }
         }
-        return null
+    }
+    return project.files(result)
+}
+
+fun getIdeaSystemProperties(
+    configDirectory: File,
+    systemDirectory: File,
+    pluginsDirectory: File,
+    requirePluginIds: List<String>,
+): Map<String, String> {
+    val result = mapOf(
+        "idea.config.path" to configDirectory.absolutePath,
+        "idea.system.path" to systemDirectory.absolutePath,
+        "idea.plugins.path" to pluginsDirectory.absolutePath,
+    )
+    if (requirePluginIds.isNotEmpty()) {
+        return result + mapOf("idea.required.plugins.id" to requirePluginIds.joinToString(","))
+    }
+    return result
+}
+
+fun getIdeJvmArgs(options: JavaForkOptions, arguments: List<String>, ideDirectory: File): List<String> {
+    options.maxHeapSize = options.maxHeapSize ?: "512m"
+    options.minHeapSize = options.minHeapSize ?: "512m"
+
+    val bootJar = File(ideDirectory, "lib/boot.jar")
+    if (bootJar.exists()) {
+        return arguments + "-Xbootclasspath/a:${bootJar.absolutePath}"
+    }
+    return arguments
+}
+
+fun ideSdkDirectory(project: Project, alternativeIdePath: String?, ideDirectory: File): File {
+    if (alternativeIdePath.isNullOrEmpty()) {
+        return ideDirectory
     }
 
-    static def unzip(@NotNull File zipFile,
-                     @NotNull File cacheDirectory,
-                     @NotNull Project project,
-                     @Nullable Predicate<File> isUpToDate,
-                     @Nullable BiConsumer<File, File> markUpToDate,
-                     @Nullable String targetDirName = null) {
-        def targetDirectory = new File(cacheDirectory, targetDirName ?: zipFile.name - ".zip")
-        def markerFile = new File(targetDirectory, "markerFile")
-        if (markerFile.exists() && (isUpToDate == null || isUpToDate.test(markerFile))) {
-            return targetDirectory
+    val dir = ideaDir(alternativeIdePath)
+    if (dir.exists()) {
+        return dir
+    }
+
+    error(project, "Cannot find alternate SDK path: $dir. Default IDE will be used : $ideDirectory")
+    return ideDirectory
+}
+
+fun ideBuildNumber(ideDirectory: File): String {
+    if (!OperatingSystem.current().isMacOsX) {
+        return File(ideDirectory, "build.txt").readText().trim()
+    }
+    File(ideDirectory, "Resources/build.txt").run {
+        if (exists()) {
+            return readText().trim()
+        }
+    }
+    return File(ideDirectory, "build.txt").readText().trim()
+}
+
+fun ideaDir(path: String) = File(path).let {
+    it.takeUnless { it.name.endsWith(".app") } ?: File(it, "Contents")
+}
+
+fun getPluginIds(project: Project) = sourcePluginXmlFiles(project).files.map {
+    parsePluginXml(it).id
+}
+
+fun parsePluginXml(file: File): PluginXml = XmlMapper()
+    .registerKotlinModule()
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    .readValue(file, PluginXml::class.java)
+
+// TODO: migrate to parsePluginXml
+fun parseXml(file: File) = parseXml(FileInputStream(file))
+
+// TODO: migrate to parsePluginXml
+fun parseXml(inputStream: InputStream): Node {
+    val parser = XmlParser(false, true, true)
+    parser.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+    parser.errorHandler = object : ErrorHandler {
+        override fun warning(exception: SAXParseException) {
         }
 
-        if (targetDirectory.exists()) {
-            targetDirectory.deleteDir()
+        override fun error(exception: SAXParseException) {
+            throw exception
         }
-        targetDirectory.mkdir()
 
-        debug(project, "Unzipping ${zipFile.name}")
-        project.copy {
-            it.from(project.zipTree(zipFile))
-            it.into(targetDirectory)
+        override fun fatalError(exception: SAXParseException) {
+            throw exception
         }
-        debug(project, "Unzipped ${zipFile.name}")
+    }
+    val input = InputSource(InputStreamReader(inputStream, "UTF-8"))
+    input.encoding = "UTF-8"
+    inputStream.use {
+        return parser.parse(input)
+    }
+}
 
-        markerFile.createNewFile()
-        if (markUpToDate != null) {
-            markUpToDate.accept(targetDirectory, markerFile)
+fun isJarFile(file: File) = file.toPath().isJar()
+
+fun isZipFile(file: File) = file.toPath().isZip()
+
+fun stringInput(input: Any?) = when (input) {
+    null -> ""
+    is Closure<*> -> input.call().toString()
+    else -> input.toString()
+}
+
+fun stringListInput(input: List<Any>) = input.map { stringInput(it) }
+
+fun collectJars(directory: File, filter: Predicate<File>): Collection<File> =
+    FileUtils.listFiles(directory, object : AbstractFileFilter() {
+        override fun accept(file: File) = isJarFile(file) && filter.test(file)
+    }, FalseFileFilter.FALSE)
+
+fun resolveToolsJar(javaExec: String): String {
+    val binDir = File(javaExec).parent
+    return when {
+        OperatingSystem.current().isMacOsX -> "$binDir/../../lib/tools.jar"
+        else -> "$binDir/../lib/tools.jar"
+    }
+}
+
+fun getBuiltinJbrVersion(ideDirectory: File): String? {
+    val dependenciesFile = File(ideDirectory, "dependencies.txt")
+    if (dependenciesFile.exists()) {
+        val properties = Properties()
+        val reader = FileReader(dependenciesFile)
+        try {
+            properties.load(reader)
+            return properties.getProperty("jdkBuild")
+        } catch (ignore: IOException) {
+        } finally {
+            reader.close()
         }
+    }
+    return null
+}
+
+fun unzip(
+    zipFile: File,
+    cacheDirectory: File,
+    project: Project,
+    isUpToDate: Predicate<File>?,
+    markUpToDate: BiConsumer<File, File>?,
+    targetDirName: String? = null,
+): File {
+    val targetDirectory = File(cacheDirectory, targetDirName ?: zipFile.name.removeSuffix(".zip"))
+    val markerFile = File(targetDirectory, "markerFile")
+    if (markerFile.exists() && (isUpToDate == null || isUpToDate.test(markerFile))) {
         return targetDirectory
     }
 
-    private static Pattern MAJOR_VERSION_PATTERN = Pattern.compile('(RIDER-)?\\d{4}\\.\\d-SNAPSHOT')
+    if (targetDirectory.exists()) {
+        targetDirectory.deleteRecursively()
+    }
+    targetDirectory.mkdir()
 
-    static String releaseType(@NotNull String version) {
-        if (version.endsWith('-EAP-SNAPSHOT') || version.endsWith('-EAP-CANDIDATE-SNAPSHOT') || version.endsWith('-CUSTOM-SNAPSHOT') || MAJOR_VERSION_PATTERN.matcher(version).matches()) {
-            return 'snapshots'
-        }
-        if (version.endsWith('-SNAPSHOT')) {
-            return 'nightly'
-        }
-        return 'releases'
+    debug(project, "Unzipping ${zipFile.name}")
+    project.copy {
+        it.from(project.zipTree(zipFile))
+        it.into(targetDirectory)
+    }
+    debug(project, "Unzipped ${zipFile.name}")
+
+    markerFile.createNewFile()
+    markUpToDate?.accept(targetDirectory, markerFile)
+    return targetDirectory
+}
+
+fun releaseType(version: String): String {
+    if (version.endsWith("-EAP-SNAPSHOT") ||
+        version.endsWith("-EAP-CANDIDATE-SNAPSHOT") ||
+        version.endsWith("-CUSTOM-SNAPSHOT") ||
+        MAJOR_VERSION_PATTERN.matcher(version).matches()
+    ) {
+        return "snapshots"
+    }
+    if (version.endsWith("-SNAPSHOT")) {
+        return "nightly"
+    }
+    return "releases"
+}
+
+// TODO simplify that - hack for Groovy
+fun error(context: Any, message: String) = log(LogLevel.ERROR, context, message, null)
+fun error(context: Any, message: String, e: Throwable) = log(LogLevel.ERROR, context, message, e)
+
+fun warn(context: Any, message: String) = log(LogLevel.WARN, context, message, null)
+fun warn(context: Any, message: String, e: Throwable) = log(LogLevel.WARN, context, message, e)
+
+fun info(context: Any, message: String) = log(LogLevel.INFO, context, message, null)
+fun info(context: Any, message: String, e: Throwable) = log(LogLevel.INFO, context, message, e)
+
+fun debug(context: Any, message: String) = log(LogLevel.DEBUG, context, message, null)
+fun debug(context: Any, message: String, e: Throwable) = log(LogLevel.DEBUG, context, message, e)
+
+fun log(level: LogLevel, context: Any, message: String, e: Throwable?) {
+    val category = when (context) {
+        is Project -> "gradle-intellij-plugin :${context.name}"
+        is Task -> "gradle-intellij-plugin :${context.project.name}:${context.name}"
+        else -> "gradle-intellij-plugin"
     }
 
-    static def error(def context, String message, Throwable e = null) {
-        log(LogLevel.ERROR, context, message, e)
+    // TODO: Use IntelliJPlugin.LOG
+    val LOG = Logging.getLogger("IntelliJPlugin")
+    if (e != null && level != LogLevel.ERROR && !LOG.isDebugEnabled) {
+        LOG.log(level, "[$category] $message. Run with --debug option to get more log output.")
+    } else {
+        LOG.log(level, "[$category] $message", e)
     }
+}
 
-    static def warn(def context, String message, Throwable e = null) {
-        log(LogLevel.WARN, context, message, e)
+fun createPlugin(artifact: File, validatePluginXml: Boolean, loggingContext: Any): IdePlugin? {
+    val creationResult = IdePluginManager.createManager().createPlugin(artifact.toPath(), validatePluginXml, IdePluginManager.PLUGIN_XML)
+    if (creationResult is PluginCreationSuccess) {
+        return creationResult.plugin
+    } else if (creationResult is PluginCreationFail) {
+        val problems = creationResult.errorsAndWarnings.filter { it.level == PluginProblem.Level.ERROR }.joinToString()
+        warn(loggingContext, "Cannot create plugin from file ($artifact): $problems")
+    } else {
+        warn(loggingContext, "Cannot create plugin from file ($artifact). $creationResult")
     }
+    return null
+}
 
-    static def info(def context, String message, Throwable e = null) {
-        log(LogLevel.INFO, context, message, e)
+fun untar(project: Project, from: File, to: File) {
+    val tempDir = File(to.parent, to.name + "-temp")
+    debug(project, "Unpacking ${from.absolutePath} to ${tempDir.absolutePath}")
+
+    if (tempDir.exists()) {
+        tempDir.deleteRecursively()
     }
+    tempDir.mkdir()
 
-    static def debug(def context, String message, Throwable e = null) {
-        log(LogLevel.DEBUG, context, message, e)
-    }
-
-    private static log(LogLevel level, def context, String message, Throwable e) {
-        if (e != null) {
-            if (level != LogLevel.ERROR && !IntelliJPlugin.LOG.isDebugEnabled()) {
-                e = null
-                message += ". Run with --debug option to get more log output."
-            }
+    if (OperatingSystem.current().isWindows) {
+        project.copy {
+            it.from(project.tarTree(from))
+            it.into(tempDir)
         }
-        def category = "gradle-intellij-plugin"
-        if (context instanceof Project) {
-            category += " :${(context as Project).name}"
+    } else {
+        project.exec {
+            it.commandLine("tar", "-xpf", from.absolutePath, "--directory", tempDir.absolutePath)
         }
-        if (context instanceof Task) {
-            category += " :${(context as Task).project.name}:${(context as Task).name}"
-        }
-        IntelliJPlugin.LOG.log(level, "[$category] $message", e as Throwable)
     }
-
-    static IdePlugin createPlugin(@NotNull File artifact, boolean validatePluginXml, def loggingContext) {
-        def creationResult = IdePluginManager.createManager().createPlugin(artifact.toPath(), validatePluginXml, IdePluginManager.PLUGIN_XML)
-        if (creationResult instanceof PluginCreationSuccess) {
-            return creationResult.plugin as IdePlugin
-        } else if (creationResult instanceof PluginCreationFail) {
-            def problems = creationResult.errorsAndWarnings.findAll { it.level == PluginProblem.Level.ERROR }.join(", ")
-            warn(loggingContext, "Cannot create plugin from file ($artifact): $problems")
-        } else {
-            warn(loggingContext, "Cannot create plugin from file ($artifact). $creationResult")
-        }
-        return null
-    }
-
-    static void untar(@NotNull Project project, @NotNull File from, @NotNull File to) {
-        def tempDir = new File(to.parent, to.name + "-temp")
-        debug(project, "Unpacking $from.absolutePath to $tempDir.absolutePath")
-
-        if (tempDir.exists()) {
-            tempDir.deleteDir()
-        }
-        tempDir.mkdir()
-
-        if (OperatingSystem.current().isWindows()) {
-            project.copy {
-                it.from project.tarTree(from)
-                it.into tempDir
-            }
-        } else {
-            project.exec {
-                commandLine 'tar', '-xpf', from.absolutePath, '--directory', tempDir.absolutePath
-            }
-        }
-        tempDir.renameTo(to)
-    }
+    tempDir.renameTo(to)
 }

--- a/src/main/kotlin/org/jetbrains/intellij/utils.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/utils.kt
@@ -84,7 +84,7 @@ fun getIdeaSystemProperties(
 
 fun getIdeJvmArgs(options: JavaForkOptions, arguments: List<String>, ideDirectory: File): List<String> {
     options.maxHeapSize = options.maxHeapSize ?: "512m"
-    options.minHeapSize = options.minHeapSize ?: "512m"
+    options.minHeapSize = options.minHeapSize ?: "256m"
 
     val bootJar = File(ideDirectory, "lib/boot.jar")
     if (bootJar.exists()) {

--- a/src/main/kotlin/org/jetbrains/intellij/utils.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/utils.kt
@@ -42,7 +42,7 @@ class Utils {
     }
 
     @NotNull
-    static IvyArtifact createJarDependency(File file, String configuration, File baseDir, String classifier = null) {
+    static IvyArtifact createjardependency(File file, String configuration, File baseDir, String classifier = null) {
         return createDependency(baseDir, file, configuration, "jar", "jar", classifier)
     }
 

--- a/src/test/kotlin/org/jetbrains/intellij/UtilsTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/UtilsTest.kt
@@ -8,10 +8,10 @@ class UtilsTest {
 
     @Test
     fun `dependency parsing`() {
-        assertEquals(PluginDependencyNotation("hello", "1.23", "alpha"), Utils.parsePluginDependencyString("hello:1.23@alpha"))
-        assertEquals(PluginDependencyNotation("hello", null, "alpha"), Utils.parsePluginDependencyString("hello:@alpha"))
-        assertEquals(PluginDependencyNotation("hello", null, "alpha"), Utils.parsePluginDependencyString("hello@alpha"))
-        assertEquals(PluginDependencyNotation("hello", null, null), Utils.parsePluginDependencyString("hello"))
-        assertEquals(PluginDependencyNotation("hello", "1.23", null), Utils.parsePluginDependencyString("hello:1.23"))
+        assertEquals(PluginDependencyNotation("hello", "1.23", "alpha"), PluginDependencyNotation.parsePluginDependencyString("hello:1.23@alpha"))
+        assertEquals(PluginDependencyNotation("hello", null, "alpha"), PluginDependencyNotation.parsePluginDependencyString("hello:@alpha"))
+        assertEquals(PluginDependencyNotation("hello", null, "alpha"), PluginDependencyNotation.parsePluginDependencyString("hello@alpha"))
+        assertEquals(PluginDependencyNotation("hello", null, null), PluginDependencyNotation.parsePluginDependencyString("hello"))
+        assertEquals(PluginDependencyNotation("hello", "1.23", null), PluginDependencyNotation.parsePluginDependencyString("hello:1.23"))
     }
 }


### PR DESCRIPTION
What’s changed:
- `parsePluginDependencyString` method moved to `PluginDependencyNotation` to avoid dependencies to non-Kotlin classes
- `Utils.ideSdkDirectory` accepts required params only instead of full extension object (same reason)
- `createJarDependency` moved to `IntellijIvyArtifact`  (again same reason)
- introduced `jackson` for XML Parsing