### PR TITLE
Fix FAQ answer to support lazy configuration

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -54,8 +54,8 @@ Running Gradle tasks from IntelliJ IDEA produces a Gradle run configuration whic
 
 ```
 prepareSandbox {
-  from('yourFile') { 
-    into "${intellij.pluginName}/lib/" 
+  from('yourFile') {
+    into "${intellij.pluginName.get()}/lib/"
   }
 }
 ```


### PR DESCRIPTION
With gradle-intellij-plugin 1.0, the value of `intellij.pluginName.toString()` is:
```
task ':prepareSandbox' property 'pluginName'
```

Thus we need to use `intellij.pluginName.get()` instead.