### PR TITLE
Fixes #451

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
@@ -420,6 +420,7 @@ open class IntelliJPlugin : Plugin<Project> {
             })
 
             it.dependsOn(JavaPlugin.JAR_TASK_NAME)
+            it.dependsOn(project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME))
 
             configure?.invoke(it)
         }


### PR DESCRIPTION
Hi,

I did some more digging on #451 and was able to find the root cause.

The problem is that the `PrepareSandboxTask` uses the jar of the project and the runtimeClasspath and puts that as an input into the Sync task. However as it does not directly pass in both into the from clause of the CopySpec ([Code](https://github.com/JetBrains/gradle-intellij-plugin/blob/55443b8651ad436eff70d6b3907cfd24f57e4f9c/src/main/kotlin/org/jetbrains/intellij/tasks/PrepareSandboxTask.kt#L80)), but instead wraps it into a provider, Gradle can no longer automatically infer the dependant tasks. For non java-library projects this still works because an explicit dependency on the jar task is declared [here](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt#L422), which transitively depends on the jar tasks of at least the compile time dependencies. I guess runtimeOnly dependencies won't work as well, but have not tried that.
The java-library projects however do not even have a dependency on the jar tasks of dependant projects in the first place ([Docs](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_classes_usage)). That's why the jars are not build and hence not bundled.

Modeling the dependency on the runtimeClasspath (which includes the jar's even for the java-library projects) fixes the problem.