### PR TITLE
Configure classpath after running executable

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/tasks/RunIdeBase.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/tasks/RunIdeBase.kt
@@ -87,10 +87,10 @@ abstract class RunIdeBase(runAlways: Boolean) : JavaExec() {
     @Override
     override fun exec() {
         workingDir = projectWorkingDir.get()
-        configureClasspath()
         configureSystemProperties()
         configureJvmArgs()
         executable(projectExecutable.get())
+        configureClasspath()
         super.exec()
     }
 


### PR DESCRIPTION
While running older versions of IntelliJ (f.e. 2018.2) the `StartupUtil#checkJdkVersion` call blocks the launch because of the runtime being used missing the `com.sun.jdi.Field` class, which is present in the tools.jar which is being resolved by `RunIdeBase#resolveToolsJar`, but in the current state this seems to be unreachable code since executable is always null