### PR TITLE
Build number fallback when product-info.json is missing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## next
 - Fixed JBR resolving for MacOSX M1
 - Fix compiler resolution for long build numbers [#883](../../issues/883)
+- Build number fallback when product-info.json is missing [#880](../../issues/880)
 
 ## 1.3.1
 - Fixed execution bit filter when extracting Rider [RIDER-72922](https://youtrack.jetbrains.com/issue/RIDER-72922)

--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
@@ -363,7 +363,13 @@ open class IntelliJPlugin : Plugin<Project> {
                     "Build-OS" to OperatingSystem.current(),
                     "Build-SDK" to when (extension.localPath.orNull) {
                         null -> "${extension.getVersionType()}-${extension.getVersionNumber()}"
-                        else -> ideProductInfo(setupDependenciesTask.idea.get().classes)?.run { "$productCode-$version" }
+                        else -> setupDependenciesTask.idea.get().classes.let { ideaClasses ->
+                            ideProductInfo(ideaClasses)
+                                ?.run { "$productCode-$version" }
+                                // Fall back on build number if product-info.json is not present, this is the case
+                                // for recent versions of Android Studio.
+                                ?: ideBuildNumber(ideaClasses)
+                        }
                     },
                 )
                 jarTask.archiveFile.orNull?.asFile


### PR DESCRIPTION
Fixes #881 

When configuring prepareSandbox we add some attributes to the jar
manifest, one of which being "Build-SDK" - when using `localPath`, the value of the attribute
is constructed from the contents of product-info.json (a metadata file located in the target IDE directory).
However, when the target IDE is Android Studio, this file does not exist (in recent versions at least), and the value thereby resolves to null; this causes the following error:

Could not determine the dependencies of task ':prepareSandbox'.
> Failed to query the value of task ':prepareSandbox' property 'pluginJar'.
   > The value of a manifest attribute must not be null (Key=Build-SDK).

This commit makes it so that we fall back on the build number (also read
from the IDE directory) if product-info.json is missing.