### PR TITLE
ProductInfo: parse custom properties in product-info.json

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/model/ProductInfo.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/model/ProductInfo.kt
@@ -12,7 +12,7 @@ data class ProductInfo(
     var dataDirectoryName: String? = null,
     var svgIconPath: String? = null,
     val launch: List<Launch> = mutableListOf(),
-    val customProperties: List<String> = mutableListOf(),
+    val customProperties: List<CustomProperty> = mutableListOf(),
 )
 
 @Serializable
@@ -21,4 +21,10 @@ data class Launch(
     var launcherPath: String? = null,
     var javaExecutablePath: String? = null,
     var vmOptionsFilePath: String? = null,
+)
+
+@Serializable
+data class CustomProperty(
+    var key: String? = null,
+    var value: String? = null
 )


### PR DESCRIPTION
Without this, any non-empty `customProperties` collection will cause JSON parse failure.