### PR TITLE
Fix compiler resolution for EAP versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## next
+- Fix compiler resolution for EAP versions [#906](../../issues/906)
+
+## 1.4.0
 - Fixed JBR resolving for MacOSX M1
 - Fixed compiler resolution for long build numbers [#883](../../issues/883)
 - Build number fallback when `product-info.json` is missing [#880](../../issues/880)

--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
@@ -32,6 +32,8 @@ import org.gradle.tooling.BuildException
 import org.jetbrains.gradle.ext.IdeaExtPlugin
 import org.jetbrains.gradle.ext.ProjectSettings
 import org.jetbrains.gradle.ext.TaskTriggersConfig
+import org.jetbrains.intellij.IntelliJPluginConstants.RELEASE_SUFFIX_EAP_CANDIDATE
+import org.jetbrains.intellij.IntelliJPluginConstants.RELEASE_SUFFIX_SNAPSHOT
 import org.jetbrains.intellij.dependency.IdeaDependency
 import org.jetbrains.intellij.dependency.IdeaDependencyManager
 import org.jetbrains.intellij.dependency.PluginDependency
@@ -700,11 +702,11 @@ open class IntelliJPlugin : Plugin<Project> {
                         val localPath = extension.localPath.orNull
                         val ideaDependency = setupDependenciesTask.idea.get()
 
-                        if (localPath.isNullOrBlank() && version.endsWith("-SNAPSHOT")) {
+                        if (localPath.isNullOrBlank() && version.endsWith(RELEASE_SUFFIX_SNAPSHOT)) {
                             val type = extension.getVersionType()
                             if (version == IntelliJPluginConstants.DEFAULT_IDEA_VERSION && listOf("CL", "RD", "PY").contains(type)) {
                                 ideProductInfo(ideaDependency.classes)?.buildNumber?.let { buildNumber ->
-                                    Version.parse(buildNumber).let { v -> "${v.major}.${v.minor}-EAP-CANDIDATE-SNAPSHOT" }
+                                    Version.parse(buildNumber).let { v -> "${v.major}.${v.minor}$RELEASE_SUFFIX_EAP_CANDIDATE" }
                                 } ?: version
                             } else {
                                 when (type) {
@@ -716,7 +718,7 @@ open class IntelliJPlugin : Plugin<Project> {
                             }
                         } else {
                             val isEap = localPath?.let { ideProductInfo(ideaDependency.classes)?.versionSuffix == "EAP" } ?: false
-                            val eapSuffix = IntelliJPluginConstants.EAP_SUFFIX.takeIf { isEap } ?: ""
+                            val eapSuffix = IntelliJPluginConstants.RELEASE_SUFFIX_EAP.takeIf { isEap } ?: ""
 
                             IdeVersion.createIdeVersion(ideaDependency.buildNumber)
                                 .stripExcessComponents()
@@ -755,9 +757,9 @@ open class IntelliJPlugin : Plugin<Project> {
                                  * for it fails - not all versions have a corresponding -EAP-SNAPSHOT version present
                                  * in the snapshot repository.
                                  */
-                                if (compilerVersion.endsWith(IntelliJPluginConstants.EAP_SUFFIX)) {
+                                if (compilerVersion.endsWith(IntelliJPluginConstants.RELEASE_SUFFIX_EAP)) {
                                     val nonEapVersion = compilerVersion.replace(
-                                        IntelliJPluginConstants.EAP_SUFFIX, ""
+                                        IntelliJPluginConstants.RELEASE_SUFFIX_EAP, ""
                                     )
                                     downloadCompiler(nonEapVersion)
                                 } else {

--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
@@ -368,8 +368,8 @@ open class IntelliJPlugin : Plugin<Project> {
                         else -> setupDependenciesTask.idea.get().classes.let { ideaClasses ->
                             ideProductInfo(ideaClasses)
                                 ?.run { "$productCode-$version" }
-                                // Fall back on build number if product-info.json is not present, this is the case
-                                // for recent versions of Android Studio.
+                            // Fall back on build number if product-info.json is not present, this is the case
+                            // for recent versions of Android Studio.
                                 ?: ideBuildNumber(ideaClasses)
                         }
                     },
@@ -734,7 +734,7 @@ open class IntelliJPlugin : Plugin<Project> {
                         if (compilerVersion == IntelliJPluginConstants.DEFAULT_IDEA_VERSION ||
                             Version.parse(compilerVersion) >= Version(183, 3795, 13)
                         ) {
-                            val downloadCompiler: (String) -> List<File> = { version ->
+                            val downloadCompiler = { version: String ->
                                 dependenciesDownloader.downloadFromMultipleRepositories(logCategory(), {
                                     create(
                                         group = "com.jetbrains.intellij.java",

--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
@@ -937,8 +937,8 @@ open class IntelliJPlugin : Plugin<Project> {
             }))
             cliVersion.convention(IntelliJPluginConstants.VERSION_LATEST)
             cliPath.convention(project.provider {
-                val resolvedCliVersion = SignPluginTask.resolveCliVersion(cliVersion.orNull)
-                val url = SignPluginTask.resolveCliUrl(resolvedCliVersion)
+                val resolvedCliVersion = resolveCliVersion(cliVersion.orNull)
+                val url = resolveCliUrl(resolvedCliVersion)
                 debug(context, "Using Marketplace ZIP Signer CLI in '$resolvedCliVersion' version")
 
                 dependenciesDownloader.downloadFromRepository(logCategory(), {

--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPluginConstants.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPluginConstants.kt
@@ -31,6 +31,15 @@ object IntelliJPluginConstants {
     const val ANNOTATIONS_DEPENDENCY_VERSION = "22.0.0"
     const val DEFAULT_IDEA_VERSION = "LATEST-EAP-SNAPSHOT"
 
+    const val RELEASE_SUFFIX_EAP = "-EAP-SNAPSHOT"
+    const val RELEASE_SUFFIX_EAP_CANDIDATE = "-EAP-CANDIDATE-SNAPSHOT"
+    const val RELEASE_SUFFIX_SNAPSHOT = "-SNAPSHOT"
+    const val RELEASE_SUFFIX_CUSTOM_SNAPSHOT = "-CUSTOM-SNAPSHOT"
+
+    const val RELEASE_TYPE_SNAPSHOTS = "snapshots"
+    const val RELEASE_TYPE_NIGHTLY = "nightly"
+    const val RELEASE_TYPE_RELEASES = "releases"
+
     const val MARKETPLACE_HOST = "https://plugins.jetbrains.com"
     const val IDEA_PRODUCTS_RELEASES_URL = "https://www.jetbrains.com/updates/updates.xml"
 //    const val ANDROID_STUDIO_PRODUCTS_RELEASES_URL = "https://dl.google.com/android/studio/patches/updates.xml"
@@ -45,6 +54,5 @@ object IntelliJPluginConstants {
     const val PLUGIN_PATH = "plugin.path"
     const val VERSION_LATEST = "latest"
     const val ANDROID_STUDIO_TYPE = "AI"
-    const val EAP_SUFFIX = "-EAP-SNAPSHOT"
 }
 

--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPluginConstants.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPluginConstants.kt
@@ -45,5 +45,6 @@ object IntelliJPluginConstants {
     const val PLUGIN_PATH = "plugin.path"
     const val VERSION_LATEST = "latest"
     const val ANDROID_STUDIO_TYPE = "AI"
+    const val EAP_SUFFIX = "-EAP-SNAPSHOT"
 }
 

--- a/src/main/kotlin/org/jetbrains/intellij/dependency/IdeaDependencyManager.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/dependency/IdeaDependencyManager.kt
@@ -11,6 +11,8 @@ import org.gradle.internal.os.OperatingSystem
 import org.gradle.kotlin.dsl.create
 import org.gradle.tooling.BuildException
 import org.jetbrains.intellij.IntelliJIvyDescriptorFileGenerator
+import org.jetbrains.intellij.IntelliJPluginConstants.RELEASE_SUFFIX_SNAPSHOT
+import org.jetbrains.intellij.IntelliJPluginConstants.RELEASE_TYPE_SNAPSHOTS
 import org.jetbrains.intellij.debug
 import org.jetbrains.intellij.ideBuildNumber
 import org.jetbrains.intellij.ideaDir
@@ -259,7 +261,7 @@ open class IdeaDependencyManager @Inject constructor(
                 "com.jetbrains.intellij.goland" to "goland"
             }
             type == "RD" -> {
-                if (sources && releaseType == "snapshots") {
+                if (sources && releaseType == RELEASE_TYPE_SNAPSHOTS) {
                     warn(context, "IDE sources are not available for Rider SNAPSHOTS")
                     hasSources = false
                 }
@@ -284,7 +286,7 @@ open class IdeaDependencyManager @Inject constructor(
             mavenRepository("$repositoryUrl/$releaseType")
         }).first().let {
             debug(context, "IDE zip: " + it.path)
-            unzipDependencyFile(getZipCacheDirectory(it, project, type), it, type, version.endsWith("-SNAPSHOT"))
+            unzipDependencyFile(getZipCacheDirectory(it, project, type), it, type, version.endsWith(RELEASE_SUFFIX_SNAPSHOT))
         }
 
         info(context, "IDE dependency cache directory: $classesDirectory")
@@ -374,7 +376,7 @@ open class IdeaDependencyManager @Inject constructor(
                     depFile.name.endsWith(".zip") -> {
                         val cacheDirectory = getZipCacheDirectory(depFile, project, "IC")
                         debug(context, "IDE extra dependency '$name': " + cacheDirectory.path)
-                        unzipDependencyFile(cacheDirectory, depFile, "IC", version.endsWith("-SNAPSHOT"))
+                        unzipDependencyFile(cacheDirectory, depFile, "IC", version.endsWith(RELEASE_SUFFIX_SNAPSHOT))
                     }
                     else -> {
                         debug(context, "IDE extra dependency '$name': " + depFile.path)

--- a/src/main/kotlin/org/jetbrains/intellij/tasks/SignPluginTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/tasks/SignPluginTask.kt
@@ -33,7 +33,9 @@ open class SignPluginTask @Inject constructor(
 ) : ConventionTask() {
 
     companion object {
-        private const val LATEST_RELEASE_URL = "https://github.com/JetBrains/marketplace-zip-signer/releases/latest"
+        private const val MARKETPLACE_ZIP_SIGNER_RELEASES_URL = "https://github.com/JetBrains/marketplace-zip-signer/releases"
+        private const val LATEST_RELEASE_URL = "$MARKETPLACE_ZIP_SIGNER_RELEASES_URL/latest"
+        private const val RELEASE_DOWNLOAD_URL = "$MARKETPLACE_ZIP_SIGNER_RELEASES_URL/download/%VERSION%/marketplace-zip-signer-cli.jar"
 
         /**
          * Resolves the latest version available of the Marketplace ZIP Signer CLI using GitHub API.
@@ -50,25 +52,6 @@ open class SignPluginTask @Inject constructor(
             } catch (e: IOException) {
                 throw GradleException("Cannot resolve the latest Marketplace ZIP Signer CLI version")
             }
-        }
-
-        /**
-         * Resolves Marketplace ZIP Signer CLI version.
-         * If set to {@link IntelliJPluginConstants#VERSION_LATEST}, there's request to {@link #METADATA_URL}
-         * performed for the latest available verifier version.
-         *
-         * @return Marketplace ZIP Signer CLI version
-         */
-        fun resolveCliVersion(version: String?) = version?.takeIf { it != IntelliJPluginConstants.VERSION_LATEST }
-            ?: resolveLatestVersion()
-
-        /**
-         * Resolves Marketplace ZIP Signer CLI download URL.
-         *
-         * @return Marketplace ZIP Signer CLI download URL
-         */
-        fun resolveCliUrl(version: String?) = resolveCliVersion(version).let {
-            "https://github.com/JetBrains/marketplace-zip-signer/releases/download/$it/marketplace-zip-signer-cli.jar"
         }
     }
 
@@ -305,5 +288,24 @@ open class SignPluginTask @Inject constructor(
         }
 
         return args
+    }
+
+    /**
+     * Resolves Marketplace ZIP Signer CLI version.
+     * If set to {@link IntelliJPluginConstants#VERSION_LATEST}, there's request to {@link #METADATA_URL}
+     * performed for the latest available verifier version.
+     *
+     * @return Marketplace ZIP Signer CLI version
+     */
+    internal fun resolveCliVersion(version: String?) = version?.takeIf { it != IntelliJPluginConstants.VERSION_LATEST }
+        ?: resolveLatestVersion()
+
+    /**
+     * Resolves Marketplace ZIP Signer CLI download URL.
+     *
+     * @return Marketplace ZIP Signer CLI download URL
+     */
+    internal fun resolveCliUrl(version: String?) = resolveCliVersion(version).let {
+        RELEASE_DOWNLOAD_URL.replace("%VERSION%", it)
     }
 }

--- a/src/main/kotlin/org/jetbrains/intellij/utils.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/utils.kt
@@ -30,6 +30,13 @@ import org.jdom2.Document
 import org.jdom2.JDOMException
 import org.jdom2.output.Format
 import org.jdom2.output.XMLOutputter
+import org.jetbrains.intellij.IntelliJPluginConstants.RELEASE_SUFFIX_CUSTOM_SNAPSHOT
+import org.jetbrains.intellij.IntelliJPluginConstants.RELEASE_SUFFIX_EAP_CANDIDATE
+import org.jetbrains.intellij.IntelliJPluginConstants.RELEASE_SUFFIX_EAP
+import org.jetbrains.intellij.IntelliJPluginConstants.RELEASE_TYPE_NIGHTLY
+import org.jetbrains.intellij.IntelliJPluginConstants.RELEASE_TYPE_RELEASES
+import org.jetbrains.intellij.IntelliJPluginConstants.RELEASE_TYPE_SNAPSHOTS
+import org.jetbrains.intellij.IntelliJPluginConstants.RELEASE_SUFFIX_SNAPSHOT
 import org.jetbrains.intellij.dependency.IdeaDependency
 import org.jetbrains.intellij.model.ProductInfo
 import org.xml.sax.SAXParseException
@@ -137,13 +144,13 @@ fun collectJars(directory: File, filter: Predicate<File>): Collection<File> = wh
 }
 
 fun releaseType(version: String) = when {
-    version.endsWith("-EAP-SNAPSHOT") ||
-        version.endsWith("-EAP-CANDIDATE-SNAPSHOT") ||
-        version.endsWith("-CUSTOM-SNAPSHOT") ||
+    version.endsWith(RELEASE_SUFFIX_EAP) ||
+        version.endsWith(RELEASE_SUFFIX_EAP_CANDIDATE) ||
+        version.endsWith(RELEASE_SUFFIX_CUSTOM_SNAPSHOT) ||
         version.matches(MAJOR_VERSION_PATTERN.toRegex())
-    -> "snapshots"
-    version.endsWith("-SNAPSHOT") -> "nightly"
-    else -> "releases"
+    -> RELEASE_TYPE_SNAPSHOTS
+    version.endsWith(RELEASE_SUFFIX_SNAPSHOT) -> RELEASE_TYPE_NIGHTLY
+    else -> RELEASE_TYPE_RELEASES
 }
 
 fun error(logCategory: String? = null, message: String, e: Throwable? = null) = log(LogLevel.ERROR, logCategory, message, e)


### PR DESCRIPTION
Fixes #903 

Try falling back on version without `-EAP-SNAPSHOT` suffix when downloading the `java-compiler-ant-tasks` dependency fails, the reason being that not all versions have a corresponding `-EAP-SNAPSHOT` version present in the snapshot repository.