### PR TITLE
Check Kotlin version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## next
 - Fixed code instrumentation disabling via `tasks.instrumentCode.enabled`
+- Check if used Kotlin version matches the bundled one
 
 ## 1.5.1
 - Add `util_rt.jar` to the classpath of run-like tasks for `2022.1+` compatibility

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation("javax.xml.bind:jaxb-api:2.3.1")
 
     api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.1.4")
+    api("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.20")
     api("com.squareup.okhttp3:okhttp:4.9.3")
     api("com.squareup.retrofit2:retrofit:2.9.0") {
         exclude("okhttp")

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -6,12 +6,12 @@ The Gradle IntelliJ Plugin already contains a set of unit tests, but in some cas
 
 Integration Tests are supposed to build the Gradle IntelliJ Plugin from the sources held in the currently used branch (i.e., for specific commits, pull request) and use it against the curated list of subprojects.
 
-Each of the Integration Tests is a standalone project that focuses on the specific flow, like patching the `plugin.xml` file, running one of the small IDEs with extra dependencies and feature implemented, etc.
+Each of the Integration Tests is a standalone project that focuses on a specific use-case, like patching the `plugin.xml` file, running one of the small IDEs with extra dependencies and feature implemented, etc.
 
 ## How it works
 
-Running Integration Tests is based on GitHub Actions and makes use of the matrix build so that we can run such tests within variations of different properties:
-- operation systems: macOS, Windows, Linux
+Running Integration Tests is based on GitHub Actions and makes use of the matrix build so that we can run all tests with variations of different properties:
+- Operating systems: macOS, Windows, Linux
 - Gradle versions:
   - first supported: `6.6.1`
   - last from `6.x` branch: `6.9.2`
@@ -32,7 +32,7 @@ It defines a couple of triggers:
 
 The very first job is `Collect Modules` which, using the dedicated [`list_integration_test_modules.main.kts`](../.github/scripts/list_integration_test_modules.main.kts) Kotlin Script that dynamically lists available modules stored in the [`integration-tests`](../integration-tests) directory.
 
-Each variation triggers the Gradle `integrationTest` dedicated task that each module can configure – i.e., to make it dependent on other tasks.
+Each variation triggers the Gradle `integrationTest` dedicated task that each subproject can configure – i.e., to make it dependent on other tasks.
 The output of this run is stored in the module's `./build/integrationTestOutput.txt` file, which is further passed to the module's `verify.main.kts` script.
 
 ### Integration Tests structure
@@ -43,19 +43,20 @@ The output of this run is stored in the module's `./build/integrationTestOutput.
 ├── integration-tests
 │   ├── README.md                 this document
 │   ├── build.gradle.kts          introduces `integrationTest` task
-│   ├── [module name]
+│   ├── [subproject name]
 │   │   ├── build                 output build directory
 │   │   ├── build.gradle.kts      custom project configuration
 │   │   ├── src                   module sources, like Java/Kotlin implementation, plugin.xml, other resources
 │   │   └── verify.main.kts       custom verification script containing assertions against build output, artifact, and Gradle output
-│   ├── settings.gradle.kts       combines modules, loads Gradle IntelliJ Plugin
+│   ├── settings.gradle.kts       combines subprojects, loads Gradle IntelliJ Plugin
 │   └── verify.utils.kts          util methods for verify.main.kts scripts which are located in modules
 └── ...
 ```
 
-To introduce a new module to the Integration Tests set, it is required to create a new directory within the `integration-tests` module and provide `build.gradle.kts`, `src`, `verify.main.kts`, similar way to other modules.
+To introduce a new subproject to the Integration Tests set, it is required to create a new directory within the `integration-tests` folder and provide `build.gradle.kts`, `src`, `verify.main.kts`.
 
-The `build.gradle.kts` should apply the Gradle IntelliJ Plugin without the version specified and define dependencies of the `integrationTest` task:
+The `build.gradle.kts` should apply the Gradle IntelliJ Plugin without specifying its version and define dependencies of the `integrationTest` task:
+
 ```kotlin
 plugins {
     id("org.jetbrains.intellij")
@@ -71,6 +72,7 @@ tasks {
 ```
 
 The `verify.main.kts` file for assertions used to check the given module's output has to import a utility file with shebang having assertions enabled:
+
 ```kotlin
 #!/usr/bin/env kotlin -J-ea
 
@@ -81,23 +83,23 @@ The `verify.main.kts` file for assertions used to check the given module's outpu
 
 ### Verification file
 
-Each module should provide the `verify.main.kts` that run assertions against files/logs produced during the run.
-The utility file provides common methods used for assertions or file handlers one may be interested in, like: `rootPath` ,`pluginXml` ,`buildOutput`.
+Each subproject must provide `verify.main.kts` that runs assertions against files/logs produced during the run.
+The utility file provides common methods used for assertions or file handlers one may be interested in, like: `workingDirPath` ,`patchedPluginXml` ,`buildDirectory`.
 
 To verify the correctness of the output, you may check if it contains specific strings or matches regular expressions:
 
 ```kotlin
-buildOutput matchesRegex ":plugin-xml-patching:patchPluginXml .*? completed."
+logs matchesRegex ":plugin-xml-patching:patchPluginXml .*? completed."
 
-pluginXml containsText "<idea-version since-build=\"2021.1\" until-build=\"2021.3.*\" />"
+patchedPluginXml containsText "<idea-version since-build=\"2021.1\" until-build=\"2021.3.*\" />"
 ```
 
 ## Running Integration Tests locally
 
 Open the Gradle Tool Window, click the `+` button, and point to the `integration-tests` directory.
 
-To perform a test of the specific module, navigate to `integration-tests > integration-tests (root) > my-module > Tasks > other > integrationTest` or use the `Run Anything...` action with `my-module:integrationTest` Gradle task directly.
-Note, if you run Gradle tasks from CLI, your working directory should be `/integration-tests` to keep all dependencies working.
+To perform a test of a specific subproject, navigate to `integration-tests > integration-tests (root) > my-subproject > Tasks > other > integrationTest` or use the `Run Anything...` action with `my-subproject:integrationTest` Gradle task directly.
+Note, if you run Gradle tasks from CLI, your working directory should be set to `/integration-tests` to keep all dependencies working.
 
 To invoke the `verify.main.kts` script, navigate to the file and click the green arrow on the first script line.
 It'll fail as it requires the path to the logs file provided; however, it opens the Terminal Tool Window when you can re-run it with the required argument.

--- a/src/main/kotlin/org/jetbrains/intellij/utils/BundledKotlinStdlib.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/utils/BundledKotlinStdlib.kt
@@ -1,0 +1,33 @@
+package org.jetbrains.intellij.utils
+
+import org.jetbrains.intellij.Version
+
+private val bundledStdlibApiMap = mapOf(
+    "2022.1" to "1.6.20",
+    "2021.3" to "1.5.10",
+    "2021.2" to "1.5.10",
+    "2021.1" to "1.4.32",
+    "2020.3" to "1.4.0",
+    "2020.2" to "1.3.70",
+    "2020.1" to "1.3.70",
+    "2019.3" to "1.3.31",
+    "2019.2" to "1.3.3",
+    "2019.1" to "1.3.11",
+)
+
+fun getBundledKotlinStdlib(ideVersion: String): String? {
+    val version = ideVersion.let(Version.Companion::parse)
+    val key = bundledStdlibApiMap.keys
+        .map(Version.Companion::parse)
+        .filter { it <= version }
+        .maxOf { it }.version
+    return bundledStdlibApiMap[key]
+}
+
+fun getClosestKotlinStdlib(kotlinVersion: String): String {
+    val version = kotlinVersion.let(Version.Companion::parse)
+    return bundledStdlibApiMap.values
+        .map(Version.Companion::parse)
+        .filter { it <= version }
+        .maxOf { it }.version
+}


### PR DESCRIPTION
Check if used Kotlin version matches the bundled one.

TODO:
- [ ] cover with integration tests
- [ ] extend docs with explanation about `compileKotlin.kotlinOptions.apiVersion`
- [ ] make the IDE-Kotlin versions map from [docs](https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library) available as a JSON list – In the intellij-sdk-docs repository
- [ ] fetch above list automatically in the Gradle IntelliJ Plugin