### PR TITLE
Set `ResolutionStrategy.SortOrder.DEPENDENCY_FIRST` for `compileClasspath` and `testCompileClasspath` configurations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 ### Added
 - Automatically detect bundled sources in plugin dependency
 - Throw an error when `intellij.version` is missing [#1010](../../issues/1004)
+- Set `ResolutionStrategy.SortOrder.DEPENDENCY_FIRST` for `compileClasspath` and `testCompileClasspath` configurations [#656](../../issues/656)
+- Added `useDependencyFirstResolutionStrategy` feature flag. See [Feature Flags](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#build-features).
 
 ### Fixed
 - Fixed broken instrumentation when custom sources directory is set [#1004](../../issues/1004)
@@ -12,7 +14,7 @@
 
 ## 1.6.0
 ### Added
-- Added `BuildFeature` feature flags. See [Feature Flags](https://github.com/JetBrains/gradle-intellij-plugin#build-features) in README.
+- Added `BuildFeature` feature flags. See [Feature Flags](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#build-features).
 - Added `--jbr-illegal-access` and `-XX:+IgnoreUnrecognizedVMOptions` flags for tasks based on `RunIdeBase` to support `2022.2` which runs on Java 17
 - For JBR 17, `dcevm` is bundled by default. As a consequence, separated `dcevm` and `nomod` variants are no longer available.
 - `instrumentCode` task – incremental instrumentation [#459](../../issues/459)

--- a/integration-tests/build-features/verify.main.kts
+++ b/integration-tests/build-features/verify.main.kts
@@ -8,4 +8,10 @@ with(__FILE__.toPath()) {
             logs containsText "Build feature is disabled: $flag"
         }
     }
+
+    "org.jetbrains.intellij.buildFeature.useDependencyFirstResolutionStrategy".let { flag ->
+        runGradleTask("assemble", projectProperties = mapOf(flag to false)).let { logs ->
+            logs containsText "Build feature is disabled: $flag"
+        }
+    }
 }

--- a/src/main/kotlin/org/jetbrains/intellij/BuildFeature.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/BuildFeature.kt
@@ -7,6 +7,7 @@ import org.jetbrains.intellij.IntelliJPluginConstants.ID as prefix
 
 enum class BuildFeature(private val defaultValue: Boolean) {
     SELF_UPDATE_CHECK(true),
+    USE_DEPENDENCY_FIRST_RESOLUTION_STRATEGY(true),
     ;
 
     fun getValue(project: Project) = project.findProperty(toString())?.toString()?.toBoolean() ?: defaultValue

--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencySet
+import org.gradle.api.artifacts.ResolutionStrategy
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.internal.artifacts.publish.ArchivePublishArtifact
@@ -36,6 +37,7 @@ import org.jetbrains.gradle.ext.IdeaExtPlugin
 import org.jetbrains.gradle.ext.ProjectSettings
 import org.jetbrains.gradle.ext.TaskTriggersConfig
 import org.jetbrains.intellij.BuildFeature.SELF_UPDATE_CHECK
+import org.jetbrains.intellij.BuildFeature.USE_DEPENDENCY_FIRST_RESOLUTION_STRATEGY
 import org.jetbrains.intellij.IntelliJPluginConstants.RELEASE_SUFFIX_EAP_CANDIDATE
 import org.jetbrains.intellij.IntelliJPluginConstants.RELEASE_SUFFIX_SNAPSHOT
 import org.jetbrains.intellij.dependency.IdeaDependency
@@ -1263,6 +1265,15 @@ open class IntelliJPlugin : Plugin<Project> {
                             )
                         }
                     }
+
+                if (project.isBuildFeatureEnabled(USE_DEPENDENCY_FIRST_RESOLUTION_STRATEGY)) {
+                    listOf(
+                        getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME),
+                        getByName(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME),
+                    ).forEach {
+                        it.resolutionStrategy.sortArtifacts(ResolutionStrategy.SortOrder.DEPENDENCY_FIRST)
+                    }
+                }
 
                 getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(defaultDependencies, idea, ideaPlugins)
                 getByName(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME).extendsFrom(defaultDependencies, idea, ideaPlugins)


### PR DESCRIPTION
… #656

# Pull Request Details

Set `ResolutionStrategy.SortOrder.DEPENDENCY_FIRST` for `compileClasspath` and `testCompileClasspath` configurations.

## Description

This change sets the `DEPENDENCY_FIRST` sort strategy for the Gradle dependencies in the project that uses the Gradle IntelliJ Plugin by default. The reason is to finally make the project dependencies not being shadowed by the IDEA and its transitive dependencies.

It is possible to disable this change using the [`useDependencyFirstResolutionStrategy` build feature flag](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#build-features-usedependencyfirstresolutionstrategy).

```properties
org.jetbrains.intellij.buildFeature.useDependencyFirstResolutionStrategy = false
```

## Related Issue

#656 

## Motivation and Context

If the project that uses the Gradle IntelliJ Plugin, defines a dependency (i.e. in a newer version) that is also present in the used IntelliJ SDK, it'll not be available due to the default dependencies resolution. `ResolutionStrategy.SortOrder.DEPENDENCY_FIRST` makes the project dependencies take precedence over IDEA dependencies.

## How Has This Been Tested

The project with PyCharm set as a dependency:

```kotlin
intellij {
    version.set("2022.1.1")
    type.set("PY")
}
```

and the following Java class:

```java
public class Sample {
    public static Pair<@NotNull String, @Nullable String> createPair() {
        return Pair.create("Something", null);
    }

    public static List<@Nls String> i18nStrings() {
        @NlsSafe String docker = "Docker";
        @NlsSafe String k8s = "K8s";
        return List.of(docker, k8s);
    }
}
```

fails due to the `java5-annotation.jar` being available in the classpath before the `org.jetbrains:annotations:23.0.0`.
Changing the resolution strategy to `DEPENDENCY_FIRST` solves that issue.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
