### PR TITLE
Warn about no settings provided by the plugin when running `buildSearchableOptions` and suggest [disabling the task](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin-faq.html#how-to-disable-building-searchable-options).

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Set `ResolutionStrategy.SortOrder.DEPENDENCY_FIRST` for `compileClasspath` and `testCompileClasspath` configurations [#656](../../issues/656)
 - Added `useDependencyFirstResolutionStrategy` feature flag. See [Feature Flags](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#build-features).
 - Ensure `classpath.index` is not bundled in the JAR file
+- Warn about no settings provided by the plugin when running `buildSearchableOptions` and suggest [disabling the task](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin-faq.html#how-to-disable-building-searchable-options).
 
 ### Changed
 - Set minimal supported Gradle version from `6.7` to `6.7.1`

--- a/integration-tests/build-features/build.gradle.kts
+++ b/integration-tests/build-features/build.gradle.kts
@@ -1,5 +1,7 @@
+val buildSearchableOptionsEnabledProperty = project.property("buildSearchableOptionsEnabled") == "true"
+
 tasks {
     buildSearchableOptions {
-        enabled = false
+        enabled = buildSearchableOptionsEnabledProperty
     }
 }

--- a/integration-tests/build-features/verify.main.kts
+++ b/integration-tests/build-features/verify.main.kts
@@ -14,4 +14,23 @@ with(__FILE__.toPath()) {
             logs containsText "Build feature is disabled: $flag"
         }
     }
+
+    "org.jetbrains.intellij.buildFeature.noSearchableOptionsWarning".let { flag ->
+        runGradleTask(
+            "clean", "jarSearchableOptions", projectProperties = mapOf(
+                "buildSearchableOptionsEnabled" to true,
+                flag to false,
+            )
+        ).let { logs ->
+            logs containsText "Build feature is disabled: $flag"
+        }
+        runGradleTask(
+            "clean", "jarSearchableOptions", projectProperties = mapOf(
+                "buildSearchableOptionsEnabled" to true,
+                flag to true,
+            )
+        ).let { logs ->
+            logs containsText "No searchable options found."
+        }
+    }
 }

--- a/src/main/kotlin/org/jetbrains/intellij/BuildFeature.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/BuildFeature.kt
@@ -6,6 +6,7 @@ import org.gradle.api.Project
 import org.jetbrains.intellij.IntelliJPluginConstants.ID as prefix
 
 enum class BuildFeature(private val defaultValue: Boolean) {
+    NO_SEARCHABLE_OPTIONS_WARNING(true),
     SELF_UPDATE_CHECK(true),
     USE_DEPENDENCY_FIRST_RESOLUTION_STRATEGY(true),
     ;

--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
@@ -36,6 +36,7 @@ import org.gradle.tooling.BuildException
 import org.jetbrains.gradle.ext.IdeaExtPlugin
 import org.jetbrains.gradle.ext.ProjectSettings
 import org.jetbrains.gradle.ext.TaskTriggersConfig
+import org.jetbrains.intellij.BuildFeature.NO_SEARCHABLE_OPTIONS_WARNING
 import org.jetbrains.intellij.BuildFeature.SELF_UPDATE_CHECK
 import org.jetbrains.intellij.BuildFeature.USE_DEPENDENCY_FIRST_RESOLUTION_STRATEGY
 import org.jetbrains.intellij.IntelliJPluginConstants.RELEASE_SUFFIX_EAP_CANDIDATE
@@ -780,6 +781,7 @@ open class IntelliJPlugin : Plugin<Project> {
             })
             archiveBaseName.convention("lib/searchableOptions")
             destinationDirectory.convention(project.layout.buildDirectory.dir("libsSearchableOptions"))
+            noSearchableOptionsWarning.convention(project.isBuildFeatureEnabled(NO_SEARCHABLE_OPTIONS_WARNING))
 
             dependsOn(IntelliJPluginConstants.BUILD_SEARCHABLE_OPTIONS_TASK_NAME)
             dependsOn(IntelliJPluginConstants.PREPARE_SANDBOX_TASK_NAME)

--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPluginConstants.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPluginConstants.kt
@@ -21,6 +21,7 @@ object IntelliJPluginConstants {
     const val RUN_IDE_FOR_UI_TESTS_TASK_NAME = "runIdeForUiTests"
     const val BUILD_SEARCHABLE_OPTIONS_TASK_NAME = "buildSearchableOptions"
     const val SEARCHABLE_OPTIONS_DIR_NAME = "searchableOptions"
+    const val SEARCHABLE_OPTIONS_SUFFIX = ".searchableOptions.xml"
     const val JAR_SEARCHABLE_OPTIONS_TASK_NAME = "jarSearchableOptions"
     const val BUILD_PLUGIN_TASK_NAME = "buildPlugin"
     const val SIGN_PLUGIN_TASK_NAME = "signPlugin"

--- a/src/test/kotlin/org/jetbrains/intellij/SearchableOptionsSpecBase.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/SearchableOptionsSpecBase.kt
@@ -62,7 +62,8 @@ abstract class SearchableOptionsSpecBase : IntelliJPluginSpecBase() {
         }
     """.trimIndent()
 
-    fun getSearchableOptionsXml(jar: String) = File(getSearchableOptions(), "/$jar.jar/search/$jar.jar.searchableOptions.xml")
+    fun getSearchableOptionsXml(jar: String) =
+        File(getSearchableOptions(), "/$jar.jar/search/$jar.jar${IntelliJPluginConstants.SEARCHABLE_OPTIONS_SUFFIX}")
 
     private fun getSearchableOptions() = File(buildDirectory, IntelliJPluginConstants.SEARCHABLE_OPTIONS_DIR_NAME)
 }


### PR DESCRIPTION
# Pull Request Details

Warn about no settings provided by the plugin when running `buildSearchableOptions` and suggest [disabling the task](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin-faq.html#how-to-disable-building-searchable-options).

## Description

The `buildSearchableOptions` task is supposed to collect all the UI elements available in the IDE Settings provided by the given plugin. Such a list is collected by running an IDE in a headless mode which is time & resources consuming.
This task is run i.e. when preparing the sandbox, building the plugin, or running the IDE for tests.
If the plugin doesn't provide such options, this operation is pointless – this change introduces a check if the `buildSearchableOptions` collected any results – if not, suggest turning it off.
Such a warning can be disabled using build features:

```properties
org.jetbrains.intellij.buildFeature.noSearchableOptionsWarning = false
```

## Motivation and Context

Educate users to disable the `buildSearchableOptions` if it is actually not needed for the sake of build performance.

## How Has This Been Tested

1. Manual tests:
- the plugin implements [Settings](https://plugins.jetbrains.com/docs/intellij/settings.html) – nothing happens
- the plugin has the `buildSearchableOptions` task disabled – nothing happens
- the plugin doesn't implement Settings – display warning with FAQ linked
- the plugin doesn't implement Settings, but has BuildFeature disabled – nothing happens
2. Integration tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [x] I have updated the documentation accordingly.
- [X] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGES.md).
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
