### PR TITLE
Warn about paid plugin running `buildSearchableOptions` and suggest [disabling the task](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin-faq.html#how-to-disable-building-searchable-options).

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,8 @@
 - Set `ResolutionStrategy.SortOrder.DEPENDENCY_FIRST` for `compileClasspath` and `testCompileClasspath` configurations [#656](../../issues/656)
 - Added `useDependencyFirstResolutionStrategy` feature flag. See [Feature Flags](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#build-features).
 - Ensure `classpath.index` is not bundled in the JAR file
-- Warn about no settings provided by the plugin when running `buildSearchableOptions` and suggest [disabling the task](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin-faq.html#how-to-disable-building-searchable-options).
+- Warn about no settings provided by the plugin when running `buildSearchableOptions` and suggest [disabling the task](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin-faq.html#how-to-disable-building-searchable-options). [#1024](../../issues/1024)
+- Warn about paid plugin running `buildSearchableOptions` and suggest [disabling the task](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin-faq.html#how-to-disable-building-searchable-options). [#1025](../../issues/1025)
 
 ### Changed
 - Set minimal supported Gradle version from `6.7` to `6.7.1`

--- a/integration-tests/build-features/build.gradle.kts
+++ b/integration-tests/build-features/build.gradle.kts
@@ -1,7 +1,9 @@
-val buildSearchableOptionsEnabledProperty = project.property("buildSearchableOptionsEnabled") == "true"
+val buildSearchableOptionsEnabledProperty = project.findProperty("buildSearchableOptionsEnabled") == "true"
+val projectExecutableProperty = project.findProperty("projectExecutable")
 
 tasks {
     buildSearchableOptions {
         enabled = buildSearchableOptionsEnabledProperty
+        projectExecutableProperty?.let { projectExecutable.set("$it") }
     }
 }

--- a/integration-tests/build-features/verify.main.kts
+++ b/integration-tests/build-features/verify.main.kts
@@ -2,6 +2,8 @@
 
 @file:Import("../verify.utils.kts")
 
+import java.nio.file.Files
+
 with(__FILE__.toPath()) {
     "org.jetbrains.intellij.buildFeature.selfUpdateCheck".let { flag ->
         runGradleTask("assemble", projectProperties = mapOf(flag to false)).let { logs ->
@@ -32,5 +34,45 @@ with(__FILE__.toPath()) {
         ).let { logs ->
             logs containsText "No searchable options found."
         }
+    }
+
+    "org.jetbrains.intellij.buildFeature.paidPluginSearchableOptionsWarning".let { flag ->
+        runGradleTask(
+            "clean", "buildSearchableOptions", projectProperties = mapOf(
+                "buildSearchableOptionsEnabled" to true,
+                flag to false,
+            )
+        ).let { logs ->
+            logs containsText "Build feature is disabled: $flag"
+        }
+
+        val pluginXml = projectDirectory.resolve("src/main/resources/META-INF/plugin.xml").also {
+            Files.createDirectories(it.parent)
+            Files.deleteIfExists(it)
+            Files.createFile(it)
+            Files.writeString(
+                it,
+                """
+                <idea-plugin>
+                    <id>test</id>
+                    <name>Test</name>
+                    <vendor>JetBrains</vendor>
+                    <product-descriptor code="GIJP" release-date="20220701" release-version="20221"/>
+                </idea-plugin>
+                """.trimIndent()
+            )
+        }
+
+        runGradleTask(
+            "clean", "buildSearchableOptions", projectProperties = mapOf(
+                "buildSearchableOptionsEnabled" to true,
+                "projectExecutable" to "echo",
+                flag to true,
+            )
+        ).let { logs ->
+            logs containsText "Due to IDE limitations, it is impossible to run the IDE in headless mode to collect searchable options for a paid plugin."
+        }
+
+        Files.delete(pluginXml)
     }
 }

--- a/src/main/kotlin/org/jetbrains/intellij/BuildFeature.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/BuildFeature.kt
@@ -7,6 +7,7 @@ import org.jetbrains.intellij.IntelliJPluginConstants.ID as prefix
 
 enum class BuildFeature(private val defaultValue: Boolean) {
     NO_SEARCHABLE_OPTIONS_WARNING(true),
+    PAID_PLUGIN_SEARCHABLE_OPTIONS_WARNING(true),
     SELF_UPDATE_CHECK(true),
     USE_DEPENDENCY_FIRST_RESOLUTION_STRATEGY(true),
     ;

--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
@@ -37,6 +37,7 @@ import org.jetbrains.gradle.ext.IdeaExtPlugin
 import org.jetbrains.gradle.ext.ProjectSettings
 import org.jetbrains.gradle.ext.TaskTriggersConfig
 import org.jetbrains.intellij.BuildFeature.NO_SEARCHABLE_OPTIONS_WARNING
+import org.jetbrains.intellij.BuildFeature.PAID_PLUGIN_SEARCHABLE_OPTIONS_WARNING
 import org.jetbrains.intellij.BuildFeature.SELF_UPDATE_CHECK
 import org.jetbrains.intellij.BuildFeature.USE_DEPENDENCY_FIRST_RESOLUTION_STRATEGY
 import org.jetbrains.intellij.IntelliJPluginConstants.RELEASE_SUFFIX_EAP_CANDIDATE
@@ -694,6 +695,13 @@ open class IntelliJPlugin : Plugin<Project> {
 
             outputDir.convention(project.provider {
                 project.layout.projectDirectory.dir("${project.buildDir}/${IntelliJPluginConstants.SEARCHABLE_OPTIONS_DIR_NAME}")
+            })
+            showPaidPluginWarning.convention(project.provider {
+                project.isBuildFeatureEnabled(PAID_PLUGIN_SEARCHABLE_OPTIONS_WARNING) && run {
+                    sourcePluginXmlFiles(project).any {
+                        parsePluginXml(it, context)?.productDescriptor != null
+                    }
+                }
             })
 
             dependsOn(IntelliJPluginConstants.PREPARE_SANDBOX_TASK_NAME)

--- a/src/main/kotlin/org/jetbrains/intellij/tasks/BuildSearchableOptionsTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/tasks/BuildSearchableOptionsTask.kt
@@ -2,10 +2,12 @@
 
 package org.jetbrains.intellij.tasks
 
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.kotlin.dsl.property
+import org.jetbrains.intellij.logCategory
+import org.jetbrains.intellij.warn
 
 @CacheableTask
 open class BuildSearchableOptionsTask : RunIdeBase(false) {
@@ -14,22 +16,40 @@ open class BuildSearchableOptionsTask : RunIdeBase(false) {
      * The directory where the searchable options will be generated.
      */
     @OutputDirectory
-    val outputDir: DirectoryProperty = objectFactory.directoryProperty()
+    val outputDir = objectFactory.directoryProperty()
+
+    /**
+     * Emit warning if the task is executed by a paid plugin.
+     * Can be disabled with [org.jetbrains.intellij.BuildFeature.PAID_PLUGIN_SEARCHABLE_OPTIONS_WARNING].
+     */
+    @Internal
+    val showPaidPluginWarning = objectFactory.property<Boolean>()
 
     private val traverseUIArgs = listOf("traverseUI")
+    private val context = logCategory()
 
     init {
         args = traverseUIArgs
     }
 
     override fun exec() {
+        if (showPaidPluginWarning.get()) {
+            warn(
+                context,
+                "Due to IDE limitations, it is impossible to run the IDE in headless mode to collect searchable options for " +
+                    "a paid plugin. As paid plugins require providing a valid license and presenting a UI dialog, it is impossible " +
+                    "to handle such a case, and the task will fail. Please consider disabling the task in the Gradle configuration. " +
+                    "See: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin-faq.html#how-to-disable-building-searchable-option"
+            )
+        }
+
         args = args + listOf(outputDir.get().asFile.canonicalPath, "true")
         super.exec()
     }
 
-    override fun setArgs(applicationArgs: List<String>?): JavaExec =
+    override fun setArgs(applicationArgs: List<String>?) =
         super.setArgs(traverseUIArgs.union(applicationArgs?.toList() ?: emptyList()))
 
-    override fun setArgs(applicationArgs: MutableIterable<*>?): JavaExec =
+    override fun setArgs(applicationArgs: MutableIterable<*>?) =
         super.setArgs(traverseUIArgs.union(applicationArgs?.toList() ?: emptyList()))
 }


### PR DESCRIPTION
# Pull Request Details

Warn about paid plugin running `buildSearchableOptions` and suggest [disabling the task](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin-faq.html#how-to-disable-building-searchable-options).

## Description

Due to IDE limitations, it is impossible to run the IDE in headless mode to collect searchable options for a paid plugin. As paid plugins require providing a valid license and presenting a UI dialog, it is impossible to handle such a case, and the task will fail. This feature flag displays the given warning when the task is run by a paid plugin.

Such a warning can be disabled using build features:

```properties
org.jetbrains.intellij.buildFeature.paidPluginSearchableOptionsWarning﻿ = false
```

## Motivation and Context

Warn paid plugin developers about the `buildSearchableOptions` in advance.

## How Has This Been Tested

Manual + integration tests:
- free plugin running the task – nothing happens
- paid plugin with `<product-descriptor>` defined in the `plugin.xml` file – emit warning

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [X] I have updated the documentation accordingly.
- [X] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGES.md).
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
