### PR TITLE
Add IDE dependencies to testFixturesCompileOnly if java-test-fixtures is applied

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Ensure `classpath.index` is not bundled in the JAR file
 - Warn about no settings provided by the plugin when running `buildSearchableOptions` and suggest [disabling the task](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin-faq.html#how-to-disable-building-searchable-options). [#1024](../../issues/1024)
 - Warn about paid plugin running `buildSearchableOptions` and suggest [disabling the task](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin-faq.html#how-to-disable-building-searchable-options). [#1025](../../issues/1025)
+- IDE dependencies are added to the compileOnly classpath for test fixtures if the `java-test-fixtures` plugin is applied
 
 ### Changed
 - Set minimal supported Gradle version from `6.7` to `6.7.1`

--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
@@ -1290,7 +1290,9 @@ open class IntelliJPlugin : Plugin<Project> {
 
                 getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(defaultDependencies, idea, ideaPlugins)
                 getByName(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME).extendsFrom(defaultDependencies, idea, ideaPlugins)
-
+                project.pluginManager.withPlugin("java-test-fixtures") {
+                    getByName("testFixturesCompileOnly").extendsFrom(defaultDependencies, idea, ideaPlugins)
+                }
                 idea
             }
 


### PR DESCRIPTION
## Description

Allows for test utilities and base classes to reference the IDE and be reused across subprojects

## Related Issue

None

## Motivation and Context

Easily allows using https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures in a multi-IDE plugin to build test utilities that can easily be re-used in multiple sub-projects.

In other words, allows for a "plugin core" to have `testFixtures` that can be exposed to a sub-part of the plugin that is IDE specific (i.e. Go support targeting Goland can leverage utilities that are IDE/language agnostic, but still use things like `Disposable`)

## How Has This Been Tested

New unit test to assert on the classpath
Custom plugin that leverages them:

Core:
```
plugins {
...
id("java-test-fixtures")
...
}
```

Jvm:
```
dependencies {
    implementation(project(":core"))

    testImplementation(testFixtures(project(":core")))
}
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [ ] I have updated the documentation accordingly.
- [x] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGES.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
