### PR TITLE
Support custom jar creation task

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Configure classpath for run-based tasks using `package-info.json` provided with IntelliJ SDK 2022.3+
 - The [`verifyPluginConfiguration`](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#tasks-verifypluginconfiguration) task for validating the plugin project configuration.
 - Make Android Studio (`AI` type) available for resolving as SDK.
+- Add `jarTaskName` to `intellij` extension to allow customization of jar creation [#808](../../issues/808)
 
 ### Changed
 - Change `IntelliJPluginConstants.ANDROID_STUDIO_PRODUCTS_RELEASES_URL` to `https://jb.gg/android-studio-releases-list.xml`
@@ -566,4 +567,3 @@
 
 ## 0.0.10
 - Support for attaching IntelliJ sources in IDEA
-

--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPluginExtension.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPluginExtension.kt
@@ -254,6 +254,11 @@ abstract class IntelliJPluginExtension @Inject constructor(
     @get:Optional
     val extraDependencies = objectFactory.listProperty<String>()
 
+    /**
+     * Name of [org.gradle.api.tasks.bundling.Jar] task that creates plugin artifact.
+     *
+     * Default value: [org.gradle.api.plugins.JavaPlugin.JAR_TASK_NAME]
+     */
     @Input
     @Optional
     val jarTaskName = objectFactory.property<String>()

--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPluginExtension.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPluginExtension.kt
@@ -254,6 +254,10 @@ abstract class IntelliJPluginExtension @Inject constructor(
     @get:Optional
     val extraDependencies = objectFactory.listProperty<String>()
 
+    @Input
+    @Optional
+    val jarTaskName = objectFactory.property<String>()
+
     @Internal
     val pluginDependencies = objectFactory.listProperty<PluginDependency>()
 


### PR DESCRIPTION
# Pull Request Details

Name of jar producer task can me customized. Task is still expected to be an instance of Gradle Jar task.

## Description

By adding ability to customize name of task that produces plugin jar it is possible to either use customized jar task or some fat jar Gradle plugin (for example [Gradle Shadow](https://imperceptiblethoughts.com/shadow/)) to assemble single jar out of multiple modules.
By convention default name is set to Gradle JAR_TASK_NAME so existing plugins do not need to change anything on update.

## Related Issue

https://github.com/JetBrains/gradle-intellij-plugin/issues/808

## Motivation and Context

Support assembly of multi module plugins into single plugin jar.

## How Has This Been Tested

With this change I was able to build a single plugin jar out of project that consists of main plugin module and 5 supporting modules. 

My project set up is quite specific, let assume I have following modules:
- plugin
- module-api
- module-A
- module-B

module-A and module-B have compileOnly dependency on module-api.

plugin module defines 2 configurations:
-  apiPluginModules
-  compileOnly.extendsFrom apiPluginModules
-  runtimePluginModules

And has following dependencies:
- apiPluginModules on module-api
- runtimePluginModules on module-A and module-B

I'm using Gradle Shadow to create fat jar and it has config like:
```
shadowJar {
  archiveClassifier.set('')
  configurations = [
      project.configurations.apiPluginModules,
      project.configurations.runtimePluginModules
  ]
}
```

intellij extension is configured like this:
```
intellij {
    ...
    jarTaskName = 'shadowJar'
}
```

Plugin distribution zip was created successfully and I was able to install it and run plugin in a 2022.2 RC Idea.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [x] I have updated the documentation accordingly.
- [x] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGES.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
