### PR TITLE
migrate most of the Gradle API in IntelliJPlugin.kt to use the Gradle Kotlin DSL extensions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Invalidate instrumented classes bound to forms if GUI changed [IDEA-298989](https://youtrack.jetbrains.com/issue/IDEA-298989/Duplicate-method-name-getFont)
 - Revert pushing project resource directories to the end of classpath in the test task context. ([#1101](../../../1161))
+- migrate most of the Gradle API in IntelliJPlugin.kt to use the Gradle Kotlin DSL extensions
 
 ## [1.9.0]
 ### Added


### PR DESCRIPTION
# Pull Request Details

Improve compatibility with Gradle API by using Gradle Kotlin DSL helper extensions


## Description

migrate most of the Gradle API in IntelliJPlugin.kt to use the Gradle Kotlin DSL extensions

## Related Issue

#1114 

## Motivation and Context
Improve compatibility with Gradle API by using Gradle Kotlin DSL helper extensions


## How Has This Been Tested

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project. - I don't know, because the code style isn't documented #1116 
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGES.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
