### PR TITLE
use XDG standards for cache dir, and use Gradle Providers API more

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Invalidate instrumented classes bound to forms if GUI changed [IDEA-298989](https://youtrack.jetbrains.com/issue/IDEA-298989/Duplicate-method-name-getFont)
 - Revert pushing project resource directories to the end of classpath in the test task context. ([#1101](../../../1161))
+- Plugin verification cache directory now follows XDG cache standards.
 
 ## [1.9.0]
 ### Added

--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
@@ -493,9 +493,7 @@ open class IntelliJPlugin : Plugin<Project> {
             verificationReportsDir.convention(project.provider {
                 "${project.buildDir}/reports/pluginVerifier"
             })
-            downloadDir.convention(project.provider {
-                ideDownloadDir().toString()
-            })
+            downloadDir.convention(ideDownloadDir().map { it.toFile().invariantSeparatorsPath })
             teamCityOutputFormat.convention(false)
             subsystemsToCheck.convention("all")
             ideDir.convention(runIdeTaskProvider.get().ideDir)

--- a/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
@@ -3,13 +3,14 @@
 package org.jetbrains.intellij.tasks
 
 import com.jetbrains.plugin.structure.base.utils.createDir
-import org.apache.commons.io.FileUtils
 import org.apache.tools.ant.util.TeeOutputStream
+import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.internal.ConventionTask
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
@@ -47,10 +48,11 @@ import java.nio.file.Paths
 import java.util.EnumSet
 import javax.inject.Inject
 
-open class RunPluginVerifierTask @Inject constructor(
+abstract class RunPluginVerifierTask @Inject constructor(
     private val objectFactory: ObjectFactory,
     private val execOperations: ExecOperations,
-) : ConventionTask() {
+    private val providers: ProviderFactory,
+) : DefaultTask() {
 
     companion object {
         private const val METADATA_URL = "$PLUGIN_VERIFIER_REPOSITORY/org/jetbrains/intellij/plugins/verifier-cli/maven-metadata.xml"
@@ -411,18 +413,19 @@ open class RunPluginVerifierTask @Inject constructor(
      *
      * @return Plugin Verifier home directory
      */
-    private fun verifierHomeDir(): Path {
-        System.getProperty("plugin.verifier.home.dir")?.let {
-            return Paths.get(it)
-        }
-
-        System.getProperty("user.home")?.let {
-            return Paths.get(it, ".pluginVerifier")
-        }
-
-        return FileUtils.getTempDirectory().toPath().resolve(".pluginVerifier")
+    private fun verifierHomeDir(): Provider<Path> {
+        return providers.systemProperty("plugin.verifier.home.dir")
+            .orElse(
+                providers.environmentVariable("XDG_CACHE_HOME").map { "$it/pluginVerifier" }
+            )
+            .orElse(
+                providers.systemProperty("user.home").map { "$it/.cache/pluginVerifier" }
+            ).map {
+                Paths.get(it)
+            }.orElse(
+                temporaryDir.resolve("pluginVerifier").toPath()
+            )
     }
-
 
     /**
      * Resolves the Plugin Verifier version.
@@ -549,7 +552,8 @@ open class RunPluginVerifierTask @Inject constructor(
      *
      * @return directory for downloaded IDEs
      */
-    internal fun ideDownloadDir() = verifierHomeDir().resolve("ides").createDir()
+    internal fun ideDownloadDir(): Provider<Path> =
+        verifierHomeDir().map { it.resolve("ides").createDir() }
 
     enum class FailureLevel(val sectionHeading: String, val message: String) {
         COMPATIBILITY_WARNINGS(


### PR DESCRIPTION
# Pull Request Details

Tries to follow XDG standards. 


## Description

* Use XDG cache home if it's available
* else use `$USER_HOME/.cache`
* I changed the system-temp dir to the task temp-dir. I suspect that `user.home` is only going to be unavailable on CI, so using the task dir is going to work the same way.
* I updated the logic to make more use of the Gradle Provider API (#1114)

## Related Issue

fixes: #1118 

related: #1114

## Motivation and Context

* better compatibility with XDG standards
* Cleaner home dir for users
* Better use of the Gradle Provider API

## How Has This Been Tested


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project #1116 
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [ ] I have updated the documentation accordingly.
- [x] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGES.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
