### PR TITLE
RunPluginVerifierTaskSpec - add fail messages to test assertions

### DIFF
--- a/src/test/kotlin/org/jetbrains/intellij/IntelliJPluginManualConfigSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/IntelliJPluginManualConfigSpec.kt
@@ -6,7 +6,7 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-@Suppress("GroovyAssignabilityCheck")
+@Suppress("GroovyAssignabilityCheck", "ComplexRedundantLet")
 class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
 
     @Test
@@ -211,11 +211,12 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
         """
         )
 
-        val result = buildAndFail("tasks")
-        assertContains(
-            "intellij is not (yet) configured. Please note that you should configure intellij dependencies in the afterEvaluate block",
-            result.output
-        )
+        buildAndFail("tasks").let {
+            assertContains(
+                "intellij is not (yet) configured. Please note that you should configure intellij dependencies in the afterEvaluate block",
+                it.output
+            )
+        }
     }
 
     @Test
@@ -232,11 +233,12 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
         """
         )
 
-        val result = buildAndFail("tasks")
-        assertContains(
-            "intellij plugin 'junit' is not (yet) configured. Please note that you should specify plugins in the intellij.plugins property and configure dependencies on them in the afterEvaluate block",
-            result.output
-        )
+        buildAndFail("tasks").let {
+            assertContains(
+                "intellij plugin 'junit' is not (yet) configured. Please note that you should specify plugins in the intellij.plugins property and configure dependencies on them in the afterEvaluate block",
+                it.output
+            )
+        }
     }
 
     @Test
@@ -258,11 +260,12 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
         """
         )
 
-        val result = buildAndFail("tasks")
-        assertContains(
-            "intellij plugin 'junit' is not found. Please note that you should specify plugins in the intellij.plugins property and configure dependencies on them in the afterEvaluate block",
-            result.output
-        )
+        buildAndFail("tasks").let {
+            assertContains(
+                "intellij plugin 'junit' is not found. Please note that you should specify plugins in the intellij.plugins property and configure dependencies on them in the afterEvaluate block",
+                it.output
+            )
+        }
     }
 
     @Test
@@ -284,11 +287,12 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
         """
         )
 
-        val result = buildAndFail("tasks")
-        assertContains(
-            "The following plugins: [testng, copyright] are not (yet) configured or not found. Please note that you should specify plugins in the intellij.plugins property and configure dependencies on them in the afterEvaluate block",
-            result.output
-        )
+        buildAndFail("tasks").let {
+            assertContains(
+                "The following plugins: [testng, copyright] are not (yet) configured or not found. Please note that you should specify plugins in the intellij.plugins property and configure dependencies on them in the afterEvaluate block",
+                it.output
+            )
+        }
     }
 
     @Test
@@ -308,11 +312,12 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
         """
         )
 
-        val result = buildAndFail("tasks")
-        assertContains(
-            "intellij is not (yet) configured. Please note that you should configure intellij dependencies in the afterEvaluate block",
-            result.output
-        )
+        buildAndFail("tasks").let {
+            assertContains(
+                "intellij is not (yet) configured. Please note that you should configure intellij dependencies in the afterEvaluate block",
+                it.output
+            )
+        }
     }
 
     @Test
@@ -334,10 +339,11 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
         """
         )
 
-        val result = buildAndFail("tasks")
-        assertContains(
-            "intellij extra artifact 'intellij-core' is not found. Please note that you should specify extra dependencies in the intellij.extraDependencies property and configure dependencies on them in the afterEvaluate block",
-            result.output
-        )
+        buildAndFail("tasks").let {
+            assertContains(
+                "intellij extra artifact 'intellij-core' is not found. Please note that you should specify extra dependencies in the intellij.extraDependencies property and configure dependencies on them in the afterEvaluate block",
+                it.output
+            )
+        }
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/IntelliJPluginManualConfigSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/IntelliJPluginManualConfigSpec.kt
@@ -13,7 +13,8 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
     fun `configure sdk manually test`() {
         writeTestFile()
 
-        buildFile.groovy("""
+        buildFile.groovy(
+            """
             import org.jetbrains.intellij.DependenciesUtils
             
             intellij {
@@ -34,7 +35,8 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
             task printMainRuntimeClassPath { doLast { println 'runtimeOnly: ' + sourceSets.main.runtimeClasspath.asPath } }
             task printTestCompileClassPath { doLast { println 'testImplementation: ' + sourceSets.test.compileClasspath.asPath } }
             task printTestRuntimeClassPath { doLast { println 'testRuntimeOnly: ' + sourceSets.test.runtimeClasspath.asPath } }
-        """)
+        """
+        )
 
         build(
             "printMainCompileClassPath",
@@ -72,7 +74,8 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
     @Test
     fun `configure plugins manually test`() {
         writeTestFile()
-        buildFile.groovy("""
+        buildFile.groovy(
+            """
             import org.jetbrains.intellij.DependenciesUtils
             
             intellij {
@@ -93,7 +96,8 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
             task printMainRuntimeClassPath { doLast { println 'runtimeOnly: ' + sourceSets.main.runtimeClasspath.asPath } }
             task printTestCompileClassPath { doLast { println 'testImplementation: ' + sourceSets.test.compileClasspath.asPath } }
             task printTestRuntimeClassPath { doLast { println 'testRuntimeOnly: ' + sourceSets.test.runtimeClasspath.asPath } }
-        """)
+        """
+        )
 
         build(
             "printMainCompileClassPath",
@@ -135,7 +139,8 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
     @Test
     fun `configure extra dependencies manually test`() {
         writeTestFile()
-        buildFile.groovy("""
+        buildFile.groovy(
+            """
             import org.jetbrains.intellij.DependenciesUtils
             
             intellij {
@@ -155,7 +160,8 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
             task printMainRuntimeClassPath { doLast { println 'runtimeOnly: ' + sourceSets.main.runtimeClasspath.asPath } }
             task printTestCompileClassPath { doLast { println 'testImplementation: ' + sourceSets.test.compileClasspath.asPath } }
             task printTestRuntimeClassPath { doLast { println 'testRuntimeOnly: ' + sourceSets.test.runtimeClasspath.asPath } }
-        """)
+        """
+        )
 
         build(
             "printMainCompileClassPath",
@@ -192,7 +198,8 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
     @Test
     fun `configure sdk manually fail without afterEvaluate`() {
         writeTestFile()
-        buildFile.groovy("""
+        buildFile.groovy(
+            """
             import org.jetbrains.intellij.DependenciesUtils
             
             intellij {
@@ -201,36 +208,42 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
             dependencies {
                 compile DependenciesUtils.intellij(project) { include('asm-all.jar') }
             } 
-        """)
+        """
+        )
 
         val result = buildAndFail("tasks")
-        assertTrue(
-            result.output.contains("intellij is not (yet) configured. Please note that you should configure intellij dependencies in the afterEvaluate block")
+        assertContains(
+            "intellij is not (yet) configured. Please note that you should configure intellij dependencies in the afterEvaluate block",
+            result.output
         )
     }
 
     @Test
     fun `configure plugins manually fail without afterEvaluate`() {
         writeTestFile()
-        buildFile.groovy("""
+        buildFile.groovy(
+            """
             import org.jetbrains.intellij.DependenciesUtils
             
             intellij.configureDefaultDependencies = false
             dependencies {
                 compile DependenciesUtils.intellijPlugin(project, 'junit')
             } 
-        """)
+        """
+        )
 
         val result = buildAndFail("tasks")
-        assertTrue(
-            result.output.contains("intellij plugin 'junit' is not (yet) configured. Please note that you should specify plugins in the intellij.plugins property and configure dependencies on them in the afterEvaluate block")
+        assertContains(
+            "intellij plugin 'junit' is not (yet) configured. Please note that you should specify plugins in the intellij.plugins property and configure dependencies on them in the afterEvaluate block",
+            result.output
         )
     }
 
     @Test
     fun `configure plugins manually fail on unconfigured plugin`() {
         writeTestFile()
-        buildFile.groovy("""
+        buildFile.groovy(
+            """
             import org.jetbrains.intellij.DependenciesUtils
 
             intellij {
@@ -242,18 +255,21 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
                     compile DependenciesUtils.intellijPlugin(project, 'junit')
                 }
             } 
-        """)
+        """
+        )
 
         val result = buildAndFail("tasks")
-        assertTrue(
-            result.output.contains("intellij plugin 'junit' is not found. Please note that you should specify plugins in the intellij.plugins property and configure dependencies on them in the afterEvaluate block")
+        assertContains(
+            "intellij plugin 'junit' is not found. Please note that you should specify plugins in the intellij.plugins property and configure dependencies on them in the afterEvaluate block",
+            result.output
         )
     }
 
     @Test
     fun `configure plugins manually fail on some unconfigured plugins`() {
         writeTestFile()
-        buildFile.groovy("""
+        buildFile.groovy(
+            """
             import org.jetbrains.intellij.DependenciesUtils
 
             intellij {
@@ -265,18 +281,21 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
                     compile DependenciesUtils.intellijPlugins(project, 'testng', 'junit', 'copyright')
                 }
             } 
-        """)
+        """
+        )
 
         val result = buildAndFail("tasks")
-        assertTrue(
-            result.output.contains("The following plugins: [testng, copyright] are not (yet) configured or not found. Please note that you should specify plugins in the intellij.plugins property and configure dependencies on them in the afterEvaluate block")
+        assertContains(
+            "The following plugins: [testng, copyright] are not (yet) configured or not found. Please note that you should specify plugins in the intellij.plugins property and configure dependencies on them in the afterEvaluate block",
+            result.output
         )
     }
 
     @Test
     fun `configure extra manually fail without afterEvaluate`() {
         writeTestFile()
-        buildFile.groovy("""
+        buildFile.groovy(
+            """
             import org.jetbrains.intellij.DependenciesUtils
             
             intellij {
@@ -286,18 +305,21 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
             dependencies {
                 compile DependenciesUtils.intellijExtra(project, 'intellij-core')
             }
-        """)
+        """
+        )
 
         val result = buildAndFail("tasks")
-        assertTrue(
-            result.output.contains("intellij is not (yet) configured. Please note that you should configure intellij dependencies in the afterEvaluate block")
+        assertContains(
+            "intellij is not (yet) configured. Please note that you should configure intellij dependencies in the afterEvaluate block",
+            result.output
         )
     }
 
     @Test
     fun `configure extra manually fail on unconfigured extra dependency`() {
         writeTestFile()
-        buildFile.groovy("""
+        buildFile.groovy(
+            """
             import org.jetbrains.intellij.DependenciesUtils
             
             intellij {
@@ -309,11 +331,13 @@ class IntelliJPluginManualConfigSpec : IntelliJPluginSpecBase() {
                     compile DependenciesUtils.intellijExtra(project, 'intellij-core')
                 }
             }
-        """)
+        """
+        )
 
         val result = buildAndFail("tasks")
-        assertTrue(
-            result.output.contains("intellij extra artifact 'intellij-core' is not found. Please note that you should specify extra dependencies in the intellij.extraDependencies property and configure dependencies on them in the afterEvaluate block")
+        assertContains(
+            "intellij extra artifact 'intellij-core' is not found. Please note that you should specify extra dependencies in the intellij.extraDependencies property and configure dependencies on them in the afterEvaluate block",
+            result.output
         )
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/IntelliJPluginSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/IntelliJPluginSpec.kt
@@ -12,7 +12,7 @@ import java.io.*
 import java.nio.file.Path
 import kotlin.test.*
 
-@Suppress("GroovyAssignabilityCheck")
+@Suppress("GroovyAssignabilityCheck", "ComplexRedundantLet")
 class IntelliJPluginSpec : IntelliJPluginSpecBase() {
 
     @Test
@@ -59,17 +59,18 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
 
         writeTestFile()
 
-        val result = build(JavaPlugin.TEST_TASK_NAME, "--info")
-        val sandboxPath = adjustWindowsPath("${buildDirectory.canonicalPath}/idea-sandbox")
-        val testCommand = parseCommand(result.output)
+        build(JavaPlugin.TEST_TASK_NAME, "--info").let {
+            val sandboxPath = adjustWindowsPath("${buildDirectory.canonicalPath}/idea-sandbox")
+            val testCommand = parseCommand(it.output)
 
-        assertPathParameters(testCommand, sandboxPath)
-        assertFalse(testCommand.properties.containsKey("idea.required.plugins.id"))
+            assertPathParameters(testCommand, sandboxPath)
+            assertFalse(testCommand.properties.containsKey("idea.required.plugins.id"))
 
-        assertEquals("boot.jar", File(testCommand.xclasspath).name)
-        assertEquals("lib", File(testCommand.xclasspath).parentFile.name)
-        assertEquals("256m", testCommand.xms)
-        assertEquals("512m", testCommand.xmx)
+            assertEquals("boot.jar", File(testCommand.xclasspath).name)
+            assertEquals("lib", File(testCommand.xclasspath).parentFile.name)
+            assertEquals("256m", testCommand.xms)
+            assertEquals("512m", testCommand.xmx)
+        }
     }
 
     @Test
@@ -209,13 +210,15 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:go:goland-GO")
-        assertContainsOnlySourceArtifacts(result,
-            "lib/src/go-openapi-src-goland-GO-212.5457.54-withSources-unzipped.com.jetbrains.plugins.jar " +
-                    "(unzipped.com.jetbrains.plugins:go:goland-GO-212.5457.54-withSources)",
-            "ideaIC-goland-GO-212.5457.54-withSources-sources.jar " +
-                    "(unzipped.com.jetbrains.plugins:go:goland-GO-212.5457.54-withSources)"
-        )
+        printSourceArtifacts("unzipped.com.jetbrains.plugins:go:goland-GO").let {
+            assertContainsOnlySourceArtifacts(
+                it,
+                "lib/src/go-openapi-src-goland-GO-212.5457.54-withSources-unzipped.com.jetbrains.plugins.jar " +
+                        "(unzipped.com.jetbrains.plugins:go:goland-GO-212.5457.54-withSources)",
+                "ideaIC-goland-GO-212.5457.54-withSources-sources.jar " +
+                        "(unzipped.com.jetbrains.plugins:go:goland-GO-212.5457.54-withSources)"
+            )
+        }
     }
 
     @Test
@@ -229,11 +232,13 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:go:goland-GO")
-        assertContainsOnlySourceArtifacts(result,
-            "lib/src/go-openapi-src-goland-GO-212.5457.54-unzipped.com.jetbrains.plugins.jar " +
-                    "(unzipped.com.jetbrains.plugins:go:goland-GO-212.5457.54)"
-        )
+        printSourceArtifacts("unzipped.com.jetbrains.plugins:go:goland-GO").let {
+            assertContainsOnlySourceArtifacts(
+                it,
+                "lib/src/go-openapi-src-goland-GO-212.5457.54-unzipped.com.jetbrains.plugins.jar " +
+                        "(unzipped.com.jetbrains.plugins:go:goland-GO-212.5457.54)"
+            )
+        }
     }
 
     @Test
@@ -247,11 +252,13 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go")
-        assertContainsOnlySourceArtifacts(result,
-            "go/lib/src/go-openapi-src-212.5712.14-unzipped.com.jetbrains.plugins.jar " +
-                    "(unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go:212.5712.14)"
-        )
+        printSourceArtifacts("unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go").let {
+            assertContainsOnlySourceArtifacts(
+                it,
+                "go/lib/src/go-openapi-src-212.5712.14-unzipped.com.jetbrains.plugins.jar " +
+                        "(unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go:212.5712.14)"
+            )
+        }
     }
 
     @Test
@@ -264,11 +271,13 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
               downloadSources = false
             }
         """)
-        val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go")
-        assertContainsOnlySourceArtifacts(result,
-            "go/lib/src/go-openapi-src-212.5712.14-unzipped.com.jetbrains.plugins.jar " +
-                    "(unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go:212.5712.14)"
-        )
+        printSourceArtifacts("unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go").let {
+            assertContainsOnlySourceArtifacts(
+                it,
+                "go/lib/src/go-openapi-src-212.5712.14-unzipped.com.jetbrains.plugins.jar " +
+                        "(unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go:212.5712.14)"
+            )
+        }
     }
 
     @Test
@@ -290,11 +299,13 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:go:ideaLocal-GO")
-        assertContainsOnlySourceArtifacts(result,
-            "lib/src/go-openapi-src-ideaLocal-GO-221.5080.224-unzipped.com.jetbrains.plugins.jar " +
-                    "(unzipped.com.jetbrains.plugins:go:ideaLocal-GO-221.5080.224)"
-        )
+        printSourceArtifacts("unzipped.com.jetbrains.plugins:go:ideaLocal-GO").let {
+            assertContainsOnlySourceArtifacts(
+                it,
+                "lib/src/go-openapi-src-ideaLocal-GO-221.5080.224-unzipped.com.jetbrains.plugins.jar " +
+                        "(unzipped.com.jetbrains.plugins:go:ideaLocal-GO-221.5080.224)"
+            )
+        }
         Path.of(localPath).forceDeleteIfExists() // clean it to save space on CI
     }
 
@@ -318,11 +329,13 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go")
-        assertContainsOnlySourceArtifacts(result,
-            "go/lib/src/go-openapi-src-212.5712.14-unzipped.com.jetbrains.plugins.jar " +
-                    "(unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go:212.5712.14)"
-        )
+        printSourceArtifacts("unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go").let {
+            assertContainsOnlySourceArtifacts(
+                it,
+                "go/lib/src/go-openapi-src-212.5712.14-unzipped.com.jetbrains.plugins.jar " +
+                        "(unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go:212.5712.14)"
+            )
+        }
         Path.of(localPath).forceDeleteIfExists() // clean it to save space on CI
     }
 
@@ -337,11 +350,13 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:CSS:ideaIU-IU-212.5712.43-withSources")
-        assertContainsOnlySourceArtifacts(result,
-            "lib/src/src_css-api-ideaIU-IU-212.5712.43-withSources.zip (unzipped.com.jetbrains.plugins:CSS:ideaIU-IU-212.5712.43-withSources)",
-            "ideaIC-ideaIU-IU-212.5712.43-withSources-sources.jar (unzipped.com.jetbrains.plugins:CSS:ideaIU-IU-212.5712.43-withSources)"
-        )
+        printSourceArtifacts("unzipped.com.jetbrains.plugins:CSS:ideaIU-IU-212.5712.43-withSources").let {
+            assertContainsOnlySourceArtifacts(
+                it,
+                "lib/src/src_css-api-ideaIU-IU-212.5712.43-withSources.zip (unzipped.com.jetbrains.plugins:CSS:ideaIU-IU-212.5712.43-withSources)",
+                "ideaIC-ideaIU-IU-212.5712.43-withSources-sources.jar (unzipped.com.jetbrains.plugins:CSS:ideaIU-IU-212.5712.43-withSources)"
+            )
+        }
     }
 
     @Test
@@ -355,10 +370,12 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:Tomcat:ideaIU-IU-212.5712.43")
-        assertContainsOnlySourceArtifacts(result,
-            "lib/src/src_tomcat-ideaIU-IU-212.5712.43.zip (unzipped.com.jetbrains.plugins:Tomcat:ideaIU-IU-212.5712.43)"
-        )
+        printSourceArtifacts("unzipped.com.jetbrains.plugins:Tomcat:ideaIU-IU-212.5712.43").let {
+            assertContainsOnlySourceArtifacts(
+                it,
+                "lib/src/src_tomcat-ideaIU-IU-212.5712.43.zip (unzipped.com.jetbrains.plugins:Tomcat:ideaIU-IU-212.5712.43)"
+            )
+        }
     }
 
     @Test
@@ -380,10 +397,12 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:Spring:ideaLocal-IU-212.5712.43")
-        assertContainsOnlySourceArtifacts(result,
-            "lib/src/src_spring-openapi-ideaLocal-IU-212.5712.43.zip (unzipped.com.jetbrains.plugins:Spring:ideaLocal-IU-212.5712.43)"
-        )
+        printSourceArtifacts("unzipped.com.jetbrains.plugins:Spring:ideaLocal-IU-212.5712.43").let {
+            assertContainsOnlySourceArtifacts(
+                it,
+                "lib/src/src_spring-openapi-ideaLocal-IU-212.5712.43.zip (unzipped.com.jetbrains.plugins:Spring:ideaLocal-IU-212.5712.43)"
+            )
+        }
         Path.of(localPath).forceDeleteIfExists() // clean it to save space on CI
     }
 
@@ -398,11 +417,13 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:CSS:goland-GO-212.5457.54-withSources")
-        assertContainsOnlySourceArtifacts(result,
-            /* no CSS plugin source artifacts in Go distribution */
-            "ideaIC-goland-GO-212.5457.54-withSources-sources.jar (unzipped.com.jetbrains.plugins:CSS:goland-GO-212.5457.54-withSources)"
-        )
+        printSourceArtifacts("unzipped.com.jetbrains.plugins:CSS:goland-GO-212.5457.54-withSources").let {
+            assertContainsOnlySourceArtifacts(
+                it,
+                /* no CSS plugin source artifacts in Go distribution */
+                "ideaIC-goland-GO-212.5457.54-withSources-sources.jar (unzipped.com.jetbrains.plugins:CSS:goland-GO-212.5457.54-withSources)"
+            )
+        }
     }
 
     @Test
@@ -417,11 +438,12 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
             </idea-plugin>
         """)
 
-        val result = build(JavaPlugin.TEST_TASK_NAME, "--info")
-        assertEquals(
-            "com.intellij.mytestid",
-            parseCommand(result.output).properties["idea.required.plugins.id"],
-        )
+        build(JavaPlugin.TEST_TASK_NAME, "--info").let {
+            assertEquals(
+                "com.intellij.mytestid",
+                parseCommand(it.output).properties["idea.required.plugins.id"],
+            )
+        }
     }
 
     @Test
@@ -435,10 +457,11 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(JavaPlugin.TEST_TASK_NAME, "--info")
-        parseCommand(result.output).let {
-            assertEquals("200m", it.xms)
-            assertEquals("500m", it.xmx)
+        build(JavaPlugin.TEST_TASK_NAME, "--info").let {
+            parseCommand(it.output).let { properties ->
+                assertEquals("200m", properties.xms)
+                assertEquals("500m", properties.xmx)
+            }
         }
     }
 
@@ -452,8 +475,9 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
                 sandboxDir = '$sandboxPath'    
             }
         """)
-        val result = build(JavaPlugin.TEST_TASK_NAME, "--info")
-        assertPathParameters(parseCommand(result.output), sandboxPath)
+        build(JavaPlugin.TEST_TASK_NAME, "--info").let {
+            assertPathParameters(parseCommand(it.output), sandboxPath)
+        }
     }
 
     @Test
@@ -520,11 +544,10 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
         )
     }
 
-    private fun buildAndGetClassPaths(vararg tasks: String): Pair<String, String> {
-        val result = build(*tasks)
-        val compileClasspath = result.output.lines().find { it.startsWith("implementation:") }.orEmpty()
-        val runtimeClasspath = result.output.lines().find { it.startsWith("runtimeOnly:") }.orEmpty()
-        return Pair(compileClasspath, runtimeClasspath)
+    private fun buildAndGetClassPaths(vararg tasks: String) = build(*tasks).run {
+        val compileClasspath = output.lines().find { it.startsWith("implementation:") }.orEmpty()
+        val runtimeClasspath = output.lines().find { it.startsWith("runtimeOnly:") }.orEmpty()
+        compileClasspath to runtimeClasspath
     }
 
     private fun assertAddedToCompileClassPathOnly(compileClasspath: String, runtimeClasspath: String, jarName: String) {

--- a/src/test/kotlin/org/jetbrains/intellij/IntelliJPluginSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/IntelliJPluginSpec.kt
@@ -210,7 +210,6 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:go:goland-GO")
-
         assertContainsOnlySourceArtifacts(result,
             "lib/src/go-openapi-src-goland-GO-212.5457.54-withSources-unzipped.com.jetbrains.plugins.jar " +
                     "(unzipped.com.jetbrains.plugins:go:goland-GO-212.5457.54-withSources)",
@@ -231,7 +230,6 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:go:goland-GO")
-
         assertContainsOnlySourceArtifacts(result,
             "lib/src/go-openapi-src-goland-GO-212.5457.54-unzipped.com.jetbrains.plugins.jar " +
                     "(unzipped.com.jetbrains.plugins:go:goland-GO-212.5457.54)"
@@ -250,7 +248,6 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go")
-
         assertContainsOnlySourceArtifacts(result,
             "go/lib/src/go-openapi-src-212.5712.14-unzipped.com.jetbrains.plugins.jar " +
                     "(unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go:212.5712.14)"
@@ -268,7 +265,6 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
             }
         """)
         val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go")
-
         assertContainsOnlySourceArtifacts(result,
             "go/lib/src/go-openapi-src-212.5712.14-unzipped.com.jetbrains.plugins.jar " +
                     "(unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go:212.5712.14)"
@@ -295,7 +291,6 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:go:ideaLocal-GO")
-
         assertContainsOnlySourceArtifacts(result,
             "lib/src/go-openapi-src-ideaLocal-GO-221.5080.224-unzipped.com.jetbrains.plugins.jar " +
                     "(unzipped.com.jetbrains.plugins:go:ideaLocal-GO-221.5080.224)"
@@ -324,7 +319,6 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go")
-
         assertContainsOnlySourceArtifacts(result,
             "go/lib/src/go-openapi-src-212.5712.14-unzipped.com.jetbrains.plugins.jar " +
                     "(unzipped.com.jetbrains.plugins:org.jetbrains.plugins.go:212.5712.14)"
@@ -344,7 +338,6 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:CSS:ideaIU-IU-212.5712.43-withSources")
-
         assertContainsOnlySourceArtifacts(result,
             "lib/src/src_css-api-ideaIU-IU-212.5712.43-withSources.zip (unzipped.com.jetbrains.plugins:CSS:ideaIU-IU-212.5712.43-withSources)",
             "ideaIC-ideaIU-IU-212.5712.43-withSources-sources.jar (unzipped.com.jetbrains.plugins:CSS:ideaIU-IU-212.5712.43-withSources)"
@@ -363,7 +356,6 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:Tomcat:ideaIU-IU-212.5712.43")
-
         assertContainsOnlySourceArtifacts(result,
             "lib/src/src_tomcat-ideaIU-IU-212.5712.43.zip (unzipped.com.jetbrains.plugins:Tomcat:ideaIU-IU-212.5712.43)"
         )
@@ -389,7 +381,6 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:Spring:ideaLocal-IU-212.5712.43")
-
         assertContainsOnlySourceArtifacts(result,
             "lib/src/src_spring-openapi-ideaLocal-IU-212.5712.43.zip (unzipped.com.jetbrains.plugins:Spring:ideaLocal-IU-212.5712.43)"
         )
@@ -408,7 +399,6 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = printSourceArtifacts("unzipped.com.jetbrains.plugins:CSS:goland-GO-212.5457.54-withSources")
-
         assertContainsOnlySourceArtifacts(result,
             /* no CSS plugin source artifacts in Go distribution */
             "ideaIC-goland-GO-212.5457.54-withSources-sources.jar (unzipped.com.jetbrains.plugins:CSS:goland-GO-212.5457.54-withSources)"

--- a/src/test/kotlin/org/jetbrains/intellij/IntelliJPluginSpecBase.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/IntelliJPluginSpecBase.kt
@@ -109,11 +109,11 @@ abstract class IntelliJPluginSpecBase {
         debugEnabled = false
     }
 
-    protected fun buildAndFail(vararg tasks: String): BuildResult = build(true, *tasks)
+    protected fun buildAndFail(vararg tasks: String) = build(true, *tasks)
 
-    protected fun build(vararg tasks: String): BuildResult = build(false, *tasks)
+    protected fun build(vararg tasks: String) = build(false, *tasks)
 
-    protected fun build(fail: Boolean, vararg tasks: String): BuildResult = build(gradleVersion, fail, *tasks)
+    protected fun build(fail: Boolean, vararg tasks: String) = build(gradleVersion, fail, *tasks)
 
     protected fun build(gradleVersion: String, fail: Boolean = false, vararg tasks: String): BuildResult =
         builder(gradleVersion, *tasks).run {

--- a/src/test/kotlin/org/jetbrains/intellij/IntelliJPluginSpecBase.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/IntelliJPluginSpecBase.kt
@@ -16,6 +16,8 @@ import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @Suppress("GroovyUnusedAssignment")
 abstract class IntelliJPluginSpecBase {
@@ -25,15 +27,18 @@ abstract class IntelliJPluginSpecBase {
     private val gradleArguments = System.getProperty("test.gradle.arguments", "")
         .split(' ').filter(String::isNotEmpty).toTypedArray()
     protected val kotlinPluginVersion: String = System.getProperty("test.kotlin.version")
-    protected val gradleVersion: String = System.getProperty("test.gradle.version").takeUnless { it.isNullOrEmpty() } ?: gradleDefault
+    protected val gradleVersion: String =
+        System.getProperty("test.gradle.version").takeUnless { it.isNullOrEmpty() } ?: gradleDefault
 
     val gradleHome: String = System.getProperty("test.gradle.home")
 
-    val pluginsRepository: String = System.getProperty("plugins.repository", IntelliJPluginConstants.DEFAULT_INTELLIJ_PLUGINS_REPOSITORY)
+    val pluginsRepository: String =
+        System.getProperty("plugins.repository", IntelliJPluginConstants.DEFAULT_INTELLIJ_PLUGINS_REPOSITORY)
     val intellijVersion: String = System.getProperty("test.intellij.version").takeUnless { it.isNullOrEmpty() }
         ?: throw GradleException("'test.intellij.version' isn't provided")
-    val testMarkdownPluginVersion: String = System.getProperty("test.markdownPlugin.version").takeUnless { it.isNullOrEmpty() }
-        ?: throw GradleException("'test.markdownPlugin.version' isn't provided")
+    val testMarkdownPluginVersion: String =
+        System.getProperty("test.markdownPlugin.version").takeUnless { it.isNullOrEmpty() }
+            ?: throw GradleException("'test.markdownPlugin.version' isn't provided")
     val dir: File by lazy { createTempDirectory("tmp").toFile() }
 
     val gradleProperties = file("gradle.properties")
@@ -126,11 +131,17 @@ abstract class IntelliJPluginSpecBase {
             .withPluginClasspath()
             .withDebug(debugEnabled)
             .withTestKitDir(File(gradleHome))
-            .withArguments(*tasks, "--stacktrace", "--configuration-cache", *gradleArguments)//, "-Dorg.gradle.debug=true")
+            .withArguments(
+                *tasks,
+                "--stacktrace",
+                "--configuration-cache",
+                *gradleArguments
+            )//, "-Dorg.gradle.debug=true")
 
     fun tasks(groupName: String): List<String> = build(ProjectInternal.TASKS_TASK).output.lines().run {
         val start = indexOfFirst { it.equals("$groupName tasks", ignoreCase = true) } + 2
-        drop(start).takeWhile { !it.startsWith('-') }.dropLast(1).map { it.substringBefore(' ') }.filterNot { it.isEmpty() }
+        drop(start).takeWhile { !it.startsWith('-') }.dropLast(1).map { it.substringBefore(' ') }
+            .filterNot { it.isEmpty() }
     }
 
     protected fun directory(path: String) = File(dir, path).apply { mkdirs() }
@@ -198,6 +209,26 @@ abstract class IntelliJPluginSpecBase {
     )
 
     fun adjustWindowsPath(s: String) = s.replace("\\", "/")
+
+    protected fun assertContains(expected: String, actual: String) {
+        // https://stackoverflow.com/questions/10934743/formatting-output-so-that-intellij-idea-shows-diffs-for-two-texts
+        assertTrue(
+            actual.contains(expected),
+            """
+                expected:<$expected> but was:<$actual>
+            """.trimIndent()
+        )
+    }
+
+    protected fun assertNotContains(expected: String, actual: String) {
+        // https://stackoverflow.com/questions/10934743/formatting-output-so-that-intellij-idea-shows-diffs-for-two-texts
+        assertFalse(
+            actual.contains(expected),
+            """
+                expected:<$expected> but was:<$actual>
+            """.trimIndent()
+        )
+    }
 
     protected fun assertFileContent(file: File?, @Language("xml") expectedContent: String) =
         assertEquals(expectedContent.trimIndent().trim(), file?.readText()?.replace("\r", "")?.trim())

--- a/src/test/kotlin/org/jetbrains/intellij/jbr/JbrResolverTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/jbr/JbrResolverTest.kt
@@ -5,8 +5,6 @@ package org.jetbrains.intellij.jbr
 import org.gradle.internal.os.OperatingSystem
 import org.jetbrains.intellij.IntelliJPluginSpecBase
 import kotlin.test.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 const val TASK_NAME = "testJbrResolver"
 
@@ -47,14 +45,9 @@ open class JbrResolverTest : IntelliJPluginSpecBase() {
             }
         """)
 
-        val output = build(TASK_NAME).output
-        output.apply {
-            assertTrue(this) {
-                contains(expected)
-            }
-            assertFalse(this) {
-                contains("Error when resolving dependency")
-            }
+        build(TASK_NAME).let {
+            assertContains(expected, it.output)
+            assertNotContains("Error when resolving dependency", it.output)
         }
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/performanceTest/parsers/IdeaLogParserTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/performanceTest/parsers/IdeaLogParserTest.kt
@@ -2,26 +2,27 @@
 
 package org.jetbrains.intellij.performanceTest.parsers
 
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class IdeaLogParserTest {
 
     @Test
     fun `simple parser test`() {
-
-        val parsed = IdeaLogParser("src/test/resources/performanceTest/idea-log/idea.log").getTestStatistic()
-        assertEquals(1_573, parsed.totalTime)
-        assertEquals(3, parsed.responsive)
-        assertEquals(777, parsed.averageResponsive)
+        IdeaLogParser("src/test/resources/performanceTest/idea-log/idea.log").getTestStatistic().let {
+            assertEquals(1_573, it.totalTime)
+            assertEquals(3, it.responsive)
+            assertEquals(777, it.averageResponsive)
+        }
     }
 
     @Test
     fun `total time absent test`() {
-        val parsed = IdeaLogParser("src/test/resources/performanceTest/idea-log/idea-no-total-time.log").getTestStatistic()
-        assertNull(parsed.totalTime)
-        assertEquals(3, parsed.responsive)
-        assertEquals(999, parsed.averageResponsive)
+        IdeaLogParser("src/test/resources/performanceTest/idea-log/idea-no-total-time.log").getTestStatistic().let {
+            assertNull(it.totalTime)
+            assertEquals(3, it.responsive)
+            assertEquals(999, it.averageResponsive)
+        }
     }
-
 }
-

--- a/src/test/kotlin/org/jetbrains/intellij/performanceTest/parsers/SimpleIJPerfParserTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/performanceTest/parsers/SimpleIJPerfParserTest.kt
@@ -20,7 +20,8 @@ class SimpleIJPerfParserTest {
                     %stopProfile traces=999,flamegraph
                     %exitApp
                     
-                """.trimIndent(), it.scriptContent
+                """.trimIndent(),
+                it.scriptContent
             )
         }
     }
@@ -37,7 +38,8 @@ class SimpleIJPerfParserTest {
                     %stopProfile traces=999,flamegraph
                     %exitApp
                     
-                """.trimIndent(), it.scriptContent
+                """.trimIndent(),
+                it.scriptContent
             )
         }
     }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/BuildPluginTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/BuildPluginTaskSpec.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-@Suppress("GroovyUnusedAssignment", "PluginXmlValidity")
+@Suppress("GroovyUnusedAssignment", "PluginXmlValidity", "ComplexRedundantLet")
 class BuildPluginTaskSpec : IntelliJPluginSpecBase() {
 
     @Test
@@ -427,18 +427,17 @@ class BuildPluginTaskSpec : IntelliJPluginSpecBase() {
         val archive = buildDirectory.resolve("distributions").resolve("projectName-0.42.123.zip")
         val artifact = extractFile(ZipFile(archive), "projectName/lib/projectName-0.42.123.jar")
 
-        val content = fileText(ZipFile(artifact), "META-INF/MANIFEST.MF")
-        val attributes = content.byteInputStream().use { Manifest(it).mainAttributes }
+        fileText(ZipFile(artifact), "META-INF/MANIFEST.MF").byteInputStream().use { Manifest(it).mainAttributes }.let {
+            assertNotNull(it)
 
-        assertNotNull(attributes)
-
-        assertEquals("1.0", attributes.getValue("Manifest-Version"))
-        assertEquals("Gradle $gradleVersion", attributes.getValue("Created-By"))
-        assertEquals(Jvm.current().toString(), attributes.getValue("Build-JVM"))
-        assertEquals("0.42.123", attributes.getValue("Version"))
-        assertEquals(IntelliJPluginConstants.NAME, attributes.getValue("Build-Plugin"))
-        assertEquals("0.0.0", attributes.getValue("Build-Plugin-Version"))
-        assertEquals(OperatingSystem.current().toString(), attributes.getValue("Build-OS"))
+            assertEquals("1.0", it.getValue("Manifest-Version"))
+            assertEquals("Gradle $gradleVersion", it.getValue("Created-By"))
+            assertEquals(Jvm.current().toString(), it.getValue("Build-JVM"))
+            assertEquals("0.42.123", it.getValue("Version"))
+            assertEquals(IntelliJPluginConstants.NAME, it.getValue("Build-Plugin"))
+            assertEquals("0.0.0", it.getValue("Build-Plugin-Version"))
+            assertEquals(OperatingSystem.current().toString(), it.getValue("Build-OS"))
+        }
     }
 
     @Test
@@ -459,7 +458,8 @@ class BuildPluginTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         build(IntelliJPluginConstants.BUILD_PLUGIN_TASK_NAME, "--configuration-cache")
-        val result = build(IntelliJPluginConstants.BUILD_PLUGIN_TASK_NAME, "--configuration-cache")
-        assertContains("Reusing configuration cache.", result.output)
+        build(IntelliJPluginConstants.BUILD_PLUGIN_TASK_NAME, "--configuration-cache").let {
+            assertContains("Reusing configuration cache.", it.output)
+        }
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/BuildPluginTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/BuildPluginTaskSpec.kt
@@ -460,7 +460,6 @@ class BuildPluginTaskSpec : IntelliJPluginSpecBase() {
 
         build(IntelliJPluginConstants.BUILD_PLUGIN_TASK_NAME, "--configuration-cache")
         val result = build(IntelliJPluginConstants.BUILD_PLUGIN_TASK_NAME, "--configuration-cache")
-
-        assertTrue(result.output.contains("Reusing configuration cache."))
+        assertContains("Reusing configuration cache.", result.output)
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/BuildSearchableOptionsTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/BuildSearchableOptionsTaskSpec.kt
@@ -5,7 +5,6 @@ package org.jetbrains.intellij.tasks
 import org.jetbrains.intellij.IntelliJPluginConstants
 import org.jetbrains.intellij.SearchableOptionsSpecBase
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
 class BuildSearchableOptionsTaskSpec : SearchableOptionsSpecBase() {
 
@@ -18,8 +17,7 @@ class BuildSearchableOptionsTaskSpec : SearchableOptionsSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.BUILD_SEARCHABLE_OPTIONS_TASK_NAME)
-
-        assertTrue(result.output.contains("${IntelliJPluginConstants.BUILD_SEARCHABLE_OPTIONS_TASK_NAME} SKIPPED"))
+        assertContains("${IntelliJPluginConstants.BUILD_SEARCHABLE_OPTIONS_TASK_NAME} SKIPPED", result.output)
     }
 
     @Test
@@ -38,19 +36,18 @@ class BuildSearchableOptionsTaskSpec : SearchableOptionsSpecBase() {
         getTestSearchableConfigurableJava().java(getSearchableConfigurableCode())
 
         val result = build(IntelliJPluginConstants.BUILD_SEARCHABLE_OPTIONS_TASK_NAME)
-        assertTrue(result.output.contains("Starting searchable options index builder"))
-        assertTrue(result.output.contains("Searchable options index builder completed"))
+        assertContains("Starting searchable options index builder", result.output)
+        assertContains("Searchable options index builder completed", result.output)
 
         val text = getSearchableOptionsXml("projectName").readText()
-        assertTrue(text.contains("<configurable id=\"test.searchable.configurable\" configurable_name=\"Test Searchable Configurable\">"))
-        assertTrue(text.contains("hit=\"Label for Test Searchable Configurable\""))
+        assertContains("<configurable id=\"test.searchable.configurable\" configurable_name=\"Test Searchable Configurable\">", text)
+        assertContains("hit=\"Label for Test Searchable Configurable\"", text)
     }
 
     @Test
     fun `reuse configuration cache`() {
         build(IntelliJPluginConstants.BUILD_SEARCHABLE_OPTIONS_TASK_NAME, "--configuration-cache")
         val result = build(IntelliJPluginConstants.BUILD_SEARCHABLE_OPTIONS_TASK_NAME, "--configuration-cache")
-
-        assertTrue(result.output.contains("Reusing configuration cache."))
+        assertContains("Reusing configuration cache.", result.output)
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/BuildSearchableOptionsTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/BuildSearchableOptionsTaskSpec.kt
@@ -6,48 +6,57 @@ import org.jetbrains.intellij.IntelliJPluginConstants
 import org.jetbrains.intellij.SearchableOptionsSpecBase
 import kotlin.test.Test
 
+@Suppress("ComplexRedundantLet")
 class BuildSearchableOptionsTaskSpec : SearchableOptionsSpecBase() {
 
     @Test
     fun `skip building searchable options using IDEA prior 2019_1`() {
-        buildFile.groovy("""
+        buildFile.groovy(
+            """
             intellij {
                 version = '14.1.4'
             } 
-        """)
+        """
+        )
 
-        val result = build(IntelliJPluginConstants.BUILD_SEARCHABLE_OPTIONS_TASK_NAME)
-        assertContains("${IntelliJPluginConstants.BUILD_SEARCHABLE_OPTIONS_TASK_NAME} SKIPPED", result.output)
+        build(IntelliJPluginConstants.BUILD_SEARCHABLE_OPTIONS_TASK_NAME).let {
+            assertContains("${IntelliJPluginConstants.BUILD_SEARCHABLE_OPTIONS_TASK_NAME} SKIPPED", it.output)
+        }
     }
 
     @Test
     fun `build searchable options produces XML`() {
         pluginXml.xml(getPluginXmlWithSearchableConfigurable())
 
-        buildFile.groovy("""
+        buildFile.groovy(
+            """
             intellij {
                 version = '$intellijVersion'
             }
             buildSearchableOptions {
                 enabled = true
             }
-        """)
+        """
+        )
 
         getTestSearchableConfigurableJava().java(getSearchableConfigurableCode())
 
-        val result = build(IntelliJPluginConstants.BUILD_SEARCHABLE_OPTIONS_TASK_NAME)
-        assertContains("Starting searchable options index builder", result.output)
-        assertContains("Searchable options index builder completed", result.output)
+        build(IntelliJPluginConstants.BUILD_SEARCHABLE_OPTIONS_TASK_NAME).let {
+            assertContains("Starting searchable options index builder", it.output)
+            assertContains("Searchable options index builder completed", it.output)
+        }
 
-        val text = getSearchableOptionsXml("projectName").readText()
-        assertContains("<configurable id=\"test.searchable.configurable\" configurable_name=\"Test Searchable Configurable\">", text)
-        assertContains("hit=\"Label for Test Searchable Configurable\"", text)
+        getSearchableOptionsXml("projectName").readText().let {
+            assertContains("<configurable id=\"test.searchable.configurable\" configurable_name=\"Test Searchable Configurable\">", it)
+            assertContains("hit=\"Label for Test Searchable Configurable\"", it)
+        }
     }
 
     @Test
     fun `reuse configuration cache`() {
         build(IntelliJPluginConstants.BUILD_SEARCHABLE_OPTIONS_TASK_NAME, "--configuration-cache")
-        val result = build(IntelliJPluginConstants.BUILD_SEARCHABLE_OPTIONS_TASK_NAME, "--configuration-cache")
-        assertContains("Reusing configuration cache.", result.output)
+        build(IntelliJPluginConstants.BUILD_SEARCHABLE_OPTIONS_TASK_NAME, "--configuration-cache").let {
+            assertContains("Reusing configuration cache.", it.output)
+        }
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/DownloadIntelliJPluginsSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/DownloadIntelliJPluginsSpec.kt
@@ -14,12 +14,9 @@ import kotlin.test.assertTrue
 class DownloadIntelliJPluginsSpec : IntelliJPluginSpecBase() {
 
     private val pluginsRepositoryCacheDir = File(gradleHome, "caches/modules-2/files-2.1/com.jetbrains.plugins")
-    private val pluginsNightlyRepositoryCacheDir =
-        File(gradleHome, "caches/modules-2/files-2.1/nightly.com.jetbrains.plugins")
-    private val pluginsCacheDir =
-        File(gradleHome, "caches/modules-2/files-2.1/com.jetbrains.intellij.idea/unzipped.com.jetbrains.plugins")
-    private val pluginsDevCacheDir =
-        File(gradleHome, "caches/modules-2/files-2.1/com.jetbrains.intellij.idea/unzipped.dev.com.jetbrains.plugins")
+    private val pluginsNightlyRepositoryCacheDir = File(gradleHome, "caches/modules-2/files-2.1/nightly.com.jetbrains.plugins")
+    private val pluginsCacheDir = File(gradleHome, "caches/modules-2/files-2.1/com.jetbrains.intellij.idea/unzipped.com.jetbrains.plugins")
+    private val pluginsDevCacheDir = File(gradleHome, "caches/modules-2/files-2.1/com.jetbrains.intellij.idea/unzipped.dev.com.jetbrains.plugins")
 
     @BeforeTest
     override fun setUp() {
@@ -46,8 +43,7 @@ class DownloadIntelliJPluginsSpec : IntelliJPluginSpecBase() {
 
         build(BasePlugin.ASSEMBLE_TASK_NAME)
         val pluginDir = File(pluginsRepositoryCacheDir, "com.intellij.lang.jsgraphql/3.1.3")
-        println("pluginDir='${pluginDir}'")
-        println("pluginDir.list()='${pluginDir.list().joinToString()}'")
+
         pluginDir.list()?.let {
             assertTrue(it.contains("66d55a3c058ca86736643dc8c9f26b7555a5aa5b"))
             assertTrue(it.contains("b87b317bc80c5773d2a1ab83390e8849e50b098b"))
@@ -71,8 +67,8 @@ class DownloadIntelliJPluginsSpec : IntelliJPluginSpecBase() {
         """)
 
         build(BasePlugin.ASSEMBLE_TASK_NAME)
-
         val pluginDir = File(pluginsNightlyRepositoryCacheDir, "dev.com.jetbrains.plugins/io.flutter/67.0.2-dev.1")
+
         pluginDir.list()?.let {
             assertTrue(it.contains("9cab70cc371b245cd808ade65630f505a6443b0d"))
         }
@@ -80,6 +76,7 @@ class DownloadIntelliJPluginsSpec : IntelliJPluginSpecBase() {
         File(pluginDir, "9cab70cc371b245cd808ade65630f505a6443b0d").list()?.let {
             assertTrue(it.contains("io.flutter-67.0.2-dev.1.zip"))
         }
+
         pluginsDevCacheDir.list()?.let {
             assertTrue(it.contains("io.flutter-67.0.2-dev.1"))
         }
@@ -94,8 +91,8 @@ class DownloadIntelliJPluginsSpec : IntelliJPluginSpecBase() {
         """)
 
         build(BasePlugin.ASSEMBLE_TASK_NAME)
-
         val pluginDir = File(pluginsRepositoryCacheDir, "com.jetbrains.plugins/org.intellij.plugins.markdown/$testMarkdownPluginVersion")
+
         pluginDir.list()?.let {
             assertTrue(it.contains("17328855fcd031f39a805db934c121eaa25dedfb"))
         }
@@ -103,6 +100,7 @@ class DownloadIntelliJPluginsSpec : IntelliJPluginSpecBase() {
         File(pluginDir, "17328855fcd031f39a805db934c121eaa25dedfb").list()?.let {
             assertTrue(it.contains("org.intellij.plugins.markdown-$testMarkdownPluginVersion.zip"))
         }
+
         File(pluginsCacheDir, "unzipped.com.jetbrains.plugins").list()?.let {
             assertTrue(it.contains("org.intellij.plugins.markdown-$testMarkdownPluginVersion"))
         }
@@ -117,11 +115,12 @@ class DownloadIntelliJPluginsSpec : IntelliJPluginSpecBase() {
         """)
 
         build(BasePlugin.ASSEMBLE_TASK_NAME)
-
         val pluginDir = File(pluginsRepositoryCacheDir, "com.jetbrains.plugins/org.jetbrains.postfixCompletion/0.8-beta")
+
         pluginDir.list()?.let {
             assertTrue(it.contains("dd37fa3fb1ecbf3d1c2fdb0049ba821fd32f2565"))
         }
+
         File(pluginDir, "dd37fa3fb1ecbf3d1c2fdb0049ba821fd32f2565").list()?.let {
             assertTrue(it.contains("org.jetbrains.postfixCompletion-0.8-beta.jar"))
         }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/DownloadRobotServerPluginTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/DownloadRobotServerPluginTaskSpec.kt
@@ -129,7 +129,6 @@ class DownloadRobotServerPluginTaskSpec : IntelliJPluginSpecBase() {
     fun `reuse configuration cache`() {
         build(IntelliJPluginConstants.DOWNLOAD_ROBOT_SERVER_PLUGIN_TASK_NAME, "--configuration-cache")
         val result = build(IntelliJPluginConstants.DOWNLOAD_ROBOT_SERVER_PLUGIN_TASK_NAME, "--configuration-cache")
-
-        assertTrue(result.output.contains("Reusing configuration cache."))
+        assertContains("Reusing configuration cache.", result.output)
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/DownloadRobotServerPluginTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/DownloadRobotServerPluginTaskSpec.kt
@@ -128,7 +128,8 @@ class DownloadRobotServerPluginTaskSpec : IntelliJPluginSpecBase() {
     @Test
     fun `reuse configuration cache`() {
         build(IntelliJPluginConstants.DOWNLOAD_ROBOT_SERVER_PLUGIN_TASK_NAME, "--configuration-cache")
-        val result = build(IntelliJPluginConstants.DOWNLOAD_ROBOT_SERVER_PLUGIN_TASK_NAME, "--configuration-cache")
-        assertContains("Reusing configuration cache.", result.output)
+        build(IntelliJPluginConstants.DOWNLOAD_ROBOT_SERVER_PLUGIN_TASK_NAME, "--configuration-cache").let {
+            assertContains("Reusing configuration cache.", it.output)
+        }
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/IntelliJInstrumentCodeTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/IntelliJInstrumentCodeTaskSpec.kt
@@ -8,6 +8,7 @@ import org.jetbrains.intellij.IntelliJPluginSpecBase
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@Suppress("ComplexRedundantLet")
 class IntelliJInstrumentCodeTaskSpec : IntelliJPluginSpecBase() {
 
     @Test
@@ -22,8 +23,9 @@ class IntelliJInstrumentCodeTaskSpec : IntelliJPluginSpecBase() {
 
         disableDebug("Gradle runs ant with another Java, that leads to NoSuchMethodError during the instrumentation")
 
-        val result = build("buildSourceSet", "--info")
-        assertContains("Added @NotNull assertions to 1 files", result.output)
+        build("buildSourceSet", "--info").let {
+            assertContains("Added @NotNull assertions to 1 files", it.output)
+        }
     }
 
     @Test
@@ -37,8 +39,9 @@ class IntelliJInstrumentCodeTaskSpec : IntelliJPluginSpecBase() {
         """)
         disableDebug("Gradle runs ant with another Java, that leads to NoSuchMethodError during the instrumentation")
 
-        val result = build("buildTestSourceSet", "--info")
-        assertContains("Added @NotNull assertions to 1 files", result.output)
+        build("buildTestSourceSet", "--info").let {
+            assertContains("Added @NotNull assertions to 1 files", it.output)
+        }
     }
 
     @Test
@@ -51,14 +54,16 @@ class IntelliJInstrumentCodeTaskSpec : IntelliJPluginSpecBase() {
 
         writeJavaFile()
 
-        val result = build("buildSourceSet", "--info")
-        assertNotContains("Added @NotNull", result.output)
+        build("buildSourceSet", "--info").let {
+            assertNotContains("Added @NotNull", it.output)
+        }
     }
 
     @Test
     fun `do not instrument code on empty source sets`() {
-        val result = build("buildSourceSet", "--info")
-        assertNotContains("Compiling forms and instrumenting code", result.output)
+        build("buildSourceSet", "--info").let {
+            assertNotContains("Compiling forms and instrumenting code", it.output)
+        }
     }
 
     @Test
@@ -87,8 +92,9 @@ class IntelliJInstrumentCodeTaskSpec : IntelliJPluginSpecBase() {
 
         disableDebug("Gradle runs ant with another Java, that leads to NoSuchMethodError during the instrumentation")
 
-        val result = build("buildSourceSet", "--info")
-        assertContains("Compiling forms and instrumenting code", result.output)
+        build("buildSourceSet", "--info").let {
+            assertContains("Compiling forms and instrumenting code", it.output)
+        }
     }
 
     @Test
@@ -98,8 +104,9 @@ class IntelliJInstrumentCodeTaskSpec : IntelliJPluginSpecBase() {
 
         build("buildSourceSet")
 
-        val result = build("buildSourceSet")
-        assertEquals(TaskOutcome.UP_TO_DATE, result.task(":${JavaPlugin.CLASSES_TASK_NAME}")?.outcome)
+        build("buildSourceSet").let {
+            assertEquals(TaskOutcome.UP_TO_DATE, it.task(":${JavaPlugin.CLASSES_TASK_NAME}")?.outcome)
+        }
     }
 
     @Test
@@ -115,7 +122,8 @@ class IntelliJInstrumentCodeTaskSpec : IntelliJPluginSpecBase() {
         disableDebug("Gradle runs ant with another Java, that leads to NoSuchMethodError during the instrumentation")
 
         build("buildSourceSet", "--configuration-cache")
-        val result = build("buildSourceSet", "--configuration-cache")
-        assertContains("Reusing configuration cache.", result.output)
+        build("buildSourceSet", "--configuration-cache").let {
+            assertContains("Reusing configuration cache.", it.output)
+        }
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/IntelliJInstrumentCodeTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/IntelliJInstrumentCodeTaskSpec.kt
@@ -7,8 +7,6 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.jetbrains.intellij.IntelliJPluginSpecBase
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class IntelliJInstrumentCodeTaskSpec : IntelliJPluginSpecBase() {
 
@@ -25,7 +23,7 @@ class IntelliJInstrumentCodeTaskSpec : IntelliJPluginSpecBase() {
         disableDebug("Gradle runs ant with another Java, that leads to NoSuchMethodError during the instrumentation")
 
         val result = build("buildSourceSet", "--info")
-        assertTrue(result.output.contains("Added @NotNull assertions to 1 files"))
+        assertContains("Added @NotNull assertions to 1 files", result.output)
     }
 
     @Test
@@ -40,7 +38,7 @@ class IntelliJInstrumentCodeTaskSpec : IntelliJPluginSpecBase() {
         disableDebug("Gradle runs ant with another Java, that leads to NoSuchMethodError during the instrumentation")
 
         val result = build("buildTestSourceSet", "--info")
-        assertTrue(result.output.contains("Added @NotNull assertions to 1 files"))
+        assertContains("Added @NotNull assertions to 1 files", result.output)
     }
 
     @Test
@@ -54,13 +52,13 @@ class IntelliJInstrumentCodeTaskSpec : IntelliJPluginSpecBase() {
         writeJavaFile()
 
         val result = build("buildSourceSet", "--info")
-        assertFalse(result.output.contains("Added @NotNull"))
+        assertNotContains("Added @NotNull", result.output)
     }
 
     @Test
     fun `do not instrument code on empty source sets`() {
         val result = build("buildSourceSet", "--info")
-        assertFalse(result.output.contains("Compiling forms and instrumenting code"))
+        assertNotContains("Compiling forms and instrumenting code", result.output)
     }
 
     @Test
@@ -90,7 +88,7 @@ class IntelliJInstrumentCodeTaskSpec : IntelliJPluginSpecBase() {
         disableDebug("Gradle runs ant with another Java, that leads to NoSuchMethodError during the instrumentation")
 
         val result = build("buildSourceSet", "--info")
-        result.output.contains("Compiling forms and instrumenting code")
+        assertContains("Compiling forms and instrumenting code", result.output)
     }
 
     @Test
@@ -118,7 +116,6 @@ class IntelliJInstrumentCodeTaskSpec : IntelliJPluginSpecBase() {
 
         build("buildSourceSet", "--configuration-cache")
         val result = build("buildSourceSet", "--configuration-cache")
-
-        assertTrue(result.output.contains("Reusing configuration cache."))
+        assertContains("Reusing configuration cache.", result.output)
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/JarSearchableOptionsTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/JarSearchableOptionsTaskSpec.kt
@@ -20,7 +20,7 @@ class JarSearchableOptionsTaskSpec : SearchableOptionsSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.JAR_SEARCHABLE_OPTIONS_TASK_NAME)
-        assertTrue(result.output.contains("${IntelliJPluginConstants.JAR_SEARCHABLE_OPTIONS_TASK_NAME} SKIPPED"))
+        assertContains("${IntelliJPluginConstants.JAR_SEARCHABLE_OPTIONS_TASK_NAME} SKIPPED", result.output)
     }
 
     @Test
@@ -55,7 +55,6 @@ class JarSearchableOptionsTaskSpec : SearchableOptionsSpecBase() {
 
         build(IntelliJPluginConstants.JAR_SEARCHABLE_OPTIONS_TASK_NAME, "--configuration-cache")
         val result = build(IntelliJPluginConstants.JAR_SEARCHABLE_OPTIONS_TASK_NAME, "--configuration-cache")
-
-        assertTrue(result.output.contains("Reusing configuration cache."))
+        assertContains("Reusing configuration cache.", result.output)
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/JarSearchableOptionsTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/JarSearchableOptionsTaskSpec.kt
@@ -19,8 +19,9 @@ class JarSearchableOptionsTaskSpec : SearchableOptionsSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.JAR_SEARCHABLE_OPTIONS_TASK_NAME)
-        assertContains("${IntelliJPluginConstants.JAR_SEARCHABLE_OPTIONS_TASK_NAME} SKIPPED", result.output)
+        build(IntelliJPluginConstants.JAR_SEARCHABLE_OPTIONS_TASK_NAME).let {
+            assertContains("${IntelliJPluginConstants.JAR_SEARCHABLE_OPTIONS_TASK_NAME} SKIPPED", it.output)
+        }
     }
 
     @Test
@@ -38,9 +39,10 @@ class JarSearchableOptionsTaskSpec : SearchableOptionsSpecBase() {
 
         build(IntelliJPluginConstants.JAR_SEARCHABLE_OPTIONS_TASK_NAME)
 
-        val libsSearchableOptions = File(buildDirectory, "libsSearchableOptions")
-        assertTrue(libsSearchableOptions.exists())
-        assertEquals(setOf("/lib/searchableOptions.jar"), collectPaths(libsSearchableOptions))
+        File(buildDirectory, "libsSearchableOptions").let {
+            assertTrue(it.exists())
+            assertEquals(setOf("/lib/searchableOptions.jar"), collectPaths(it))
+        }
     }
 
     @Test
@@ -54,7 +56,8 @@ class JarSearchableOptionsTaskSpec : SearchableOptionsSpecBase() {
         getTestSearchableConfigurableJava().java(getSearchableConfigurableCode())
 
         build(IntelliJPluginConstants.JAR_SEARCHABLE_OPTIONS_TASK_NAME, "--configuration-cache")
-        val result = build(IntelliJPluginConstants.JAR_SEARCHABLE_OPTIONS_TASK_NAME, "--configuration-cache")
-        assertContains("Reusing configuration cache.", result.output)
+        build(IntelliJPluginConstants.JAR_SEARCHABLE_OPTIONS_TASK_NAME, "--configuration-cache").let {
+            assertContains("Reusing configuration cache.", it.output)
+        }
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/ListProductsReleasesTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/ListProductsReleasesTaskSpec.kt
@@ -10,6 +10,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@Suppress("ComplexRedundantLet")
 class ListProductsReleasesTaskSpec : IntelliJPluginSpecBase() {
 
     @BeforeTest
@@ -36,12 +37,9 @@ class ListProductsReleasesTaskSpec : IntelliJPluginSpecBase() {
 
     @Test
     fun `get IDEs list for the current platformType, sinceBuild and untilBuild`() {
-        val result = build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME)
-
-        assertEquals(
-            listOf("IC-2020.1.4"),
-            result.taskOutput()
-        )
+        build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME).let {
+            assertEquals(listOf("IC-2020.1.4"), it.taskOutput())
+        }
     }
 
     @Test
@@ -52,18 +50,18 @@ class ListProductsReleasesTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME)
-
-        assertEquals(
-            listOf(
-                "IC-2021.2.2",
-                "IC-2021.1.3",
-                "IC-2020.3.4",
-                "IC-2020.2.4",
-                "IC-2020.1.4",
-            ),
-            result.taskOutput()
-        )
+        build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME).let {
+            assertEquals(
+                listOf(
+                    "IC-2021.2.2",
+                    "IC-2021.1.3",
+                    "IC-2020.3.4",
+                    "IC-2020.2.4",
+                    "IC-2020.1.4",
+                ),
+                it.taskOutput()
+            )
+        }
     }
 
     @Test
@@ -75,16 +73,16 @@ class ListProductsReleasesTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME)
-
-        assertEquals(
-            listOf(
-                "IC-2021.2.1",
-                "IC-2021.1.3",
-                "IC-2020.3.4"
-            ),
-            result.taskOutput()
-        )
+        build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME).let {
+            assertEquals(
+                listOf(
+                    "IC-2021.2.1",
+                    "IC-2021.1.3",
+                    "IC-2020.3.4"
+                ),
+                it.taskOutput()
+            )
+        }
     }
 
     @Test
@@ -96,16 +94,16 @@ class ListProductsReleasesTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME)
-
-        assertEquals(
-            listOf(
-                "IC-2021.2.2",
-                "IC-2021.1.3",
-                "IC-2020.3.4",
-            ),
-            result.taskOutput()
-        )
+        build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME).let {
+            assertEquals(
+                listOf(
+                    "IC-2021.2.2",
+                    "IC-2021.1.3",
+                    "IC-2020.3.4",
+                ),
+                it.taskOutput()
+            )
+        }
     }
 
     @Test
@@ -120,16 +118,16 @@ class ListProductsReleasesTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME)
-
-        assertEquals(
-            listOf(
-                "IC-2021.2.2",
-                "IC-2021.1.3",
-                "IC-2020.3.4",
-            ),
-            result.taskOutput()
-        )
+        build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME).let {
+            assertEquals(
+                listOf(
+                    "IC-2021.2.2",
+                    "IC-2021.1.3",
+                    "IC-2020.3.4",
+                ),
+                it.taskOutput()
+            )
+        }
     }
 
     @Test
@@ -141,12 +139,12 @@ class ListProductsReleasesTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME)
-
-        assertEquals(
-            listOf("PY-2021.1.3"),
-            result.taskOutput()
-        )
+        build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME).let {
+            assertEquals(
+                listOf("PY-2021.1.3"),
+                it.taskOutput()
+            )
+        }
     }
 
     @Test
@@ -160,18 +158,17 @@ class ListProductsReleasesTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME)
-
-        assertEquals(
-            listOf(
-                // "IC-2021.2.2" - available only in the EAP channel and shouldn't be listed here
-                "IC-2021.2.1",
-                "IC-2021.1.3"
-            ),
-            result.taskOutput()
-        )
+        build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME).let {
+            assertEquals(
+                listOf(
+                    // "IC-2021.2.2" - available only in the EAP channel and shouldn't be listed here
+                    "IC-2021.2.1",
+                    "IC-2021.1.3"
+                ),
+                it.taskOutput()
+            )
+        }
     }
-
     @Test
     fun `get IDEs list for the multiple platformTypes`() {
         buildFile.groovy("""
@@ -181,19 +178,19 @@ class ListProductsReleasesTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME)
-
-        assertEquals(
-            listOf(
-                "IU-2021.2.2",
-                "IU-2021.1.3",
-                "PS-2021.2.2",
-                "PS-2021.1.4",
-                "PY-2021.2.2",
-                "PY-2021.1.3",
-            ),
-            result.taskOutput()
-        )
+        build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME).let {
+            assertEquals(
+                listOf(
+                    "IU-2021.2.2",
+                    "IU-2021.1.3",
+                    "PS-2021.2.2",
+                    "PS-2021.1.4",
+                    "PY-2021.2.2",
+                    "PY-2021.1.3",
+                ),
+                it.taskOutput()
+            )
+        }
     }
 
     @Test
@@ -205,16 +202,16 @@ class ListProductsReleasesTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME)
-
-        assertEquals(
-            listOf(
-                "AI-2021.3.1.7",
-                "AI-2021.2.1.11",
-                "AI-2021.1.1.22",
-            ),
-            result.taskOutput()
-        )
+        build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME).let {
+            assertEquals(
+                listOf(
+                    "AI-2021.3.1.7",
+                    "AI-2021.2.1.11",
+                    "AI-2021.1.1.22",
+                ),
+                it.taskOutput()
+            )
+        }
     }
 
     @Test
@@ -229,19 +226,19 @@ class ListProductsReleasesTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME)
-
-        assertEquals(
-            listOf("AI-2021.1.1.20"),
-            result.taskOutput()
-        )
+        build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME).let {
+            assertEquals(
+                listOf("AI-2021.1.1.20"),
+                it.taskOutput()
+            )
+        }
     }
-
     @Test
     fun `reuse configuration cache`() {
         build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME, "--configuration-cache")
-        val result = build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME, "--configuration-cache")
-        assertContains("Reusing configuration cache.", result.output)
+        build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME, "--configuration-cache").let {
+            assertContains("Reusing configuration cache.", it.output)
+        }
     }
 
     private fun BuildResult.taskOutput() = output.lines().run {

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/ListProductsReleasesTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/ListProductsReleasesTaskSpec.kt
@@ -9,7 +9,6 @@ import org.jetbrains.intellij.Version
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class ListProductsReleasesTaskSpec : IntelliJPluginSpecBase() {
 
@@ -242,8 +241,7 @@ class ListProductsReleasesTaskSpec : IntelliJPluginSpecBase() {
     fun `reuse configuration cache`() {
         build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME, "--configuration-cache")
         val result = build(IntelliJPluginConstants.LIST_PRODUCTS_RELEASES_TASK_NAME, "--configuration-cache")
-
-        assertTrue(result.output.contains("Reusing configuration cache."))
+        assertContains("Reusing configuration cache.", result.output)
     }
 
     private fun BuildResult.taskOutput() = output.lines().run {

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/PatchPluginXmlTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/PatchPluginXmlTaskSpec.kt
@@ -39,7 +39,7 @@ class PatchPluginXmlTaskSpec : IntelliJPluginSpecBase() {
             </idea-plugin>
         """)
 
-        assertFalse(result.output.contains("will be overwritten"))
+        assertNotContains("will be overwritten", result.output)
     }
 
     @Test
@@ -394,7 +394,6 @@ class PatchPluginXmlTaskSpec : IntelliJPluginSpecBase() {
 
         build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME, "--configuration-cache")
         val result = build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME, "--configuration-cache")
-
-        assertTrue(result.output.contains("Reusing configuration cache."))
+        assertContains("Reusing configuration cache.", result.output)
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/PatchPluginXmlTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/PatchPluginXmlTaskSpec.kt
@@ -30,16 +30,18 @@ class PatchPluginXmlTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME)
-
-        assertFileContent(patchedPluginXml.value, """
-            <idea-plugin>
-              <version>0.42.123</version>
-              <idea-version since-build="141.1532" until-build="141.*" />
-            </idea-plugin>
-        """)
-
-        assertNotContains("will be overwritten", result.output)
+        build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).let {
+            assertFileContent(
+                patchedPluginXml.value,
+                """
+                    <idea-plugin>
+                      <version>0.42.123</version>
+                      <idea-version since-build="141.1532" until-build="141.*" />
+                    </idea-plugin>
+                """
+            )
+            assertNotContains("will be overwritten", it.output)
+        }
     }
 
     @Test
@@ -58,17 +60,20 @@ class PatchPluginXmlTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val output = build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).output
+        build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).let {
+            assertFileContent(
+                patchedPluginXml.value,
+                """
+                    <idea-plugin>
+                      <version>0.42.123</version>
+                      <description>Plugin pluginDescription</description>
+                      <idea-version since-build="141.1532" until-build="141.*" />
+                    </idea-plugin>
+                """
+            )
 
-        assertFileContent(patchedPluginXml.value, """
-            <idea-plugin>
-              <version>0.42.123</version>
-              <description>Plugin pluginDescription</description>
-              <idea-version since-build="141.1532" until-build="141.*" />
-            </idea-plugin>
-        """)
-
-        assertFalse(output.contains("will be overwritten"))
+            assertNotContains("will be overwritten", it.output)
+        }
     }
 
     @Test
@@ -84,16 +89,19 @@ class PatchPluginXmlTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val output = build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).output
+        build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).let {
+            assertFileContent(
+                patchedPluginXml.value,
+                """
+                    <idea-plugin someattr="\u2202">
+                      <version>0.42.123</version>
+                      <idea-version since-build="141.1532" until-build="141.*" />
+                    </idea-plugin>
+                """
+            )
 
-        assertFileContent(patchedPluginXml.value, """
-            <idea-plugin someattr="\u2202">
-              <version>0.42.123</version>
-              <idea-version since-build="141.1532" until-build="141.*" />
-            </idea-plugin>
-        """)
-
-        assertFalse(output.contains("will be overwritten"))
+            assertNotContains("will be overwritten", it.output)
+        }
     }
 
     @Test
@@ -112,17 +120,20 @@ class PatchPluginXmlTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val output = build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).output
+        build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).let {
+            assertFileContent(
+                patchedPluginXml.value,
+                """
+                    <idea-plugin>
+                      <version>0.42.123</version>
+                      <change-notes>change notes</change-notes>
+                      <idea-version since-build="141.1532" until-build="141.*" />
+                    </idea-plugin>
+                """
+            )
 
-        assertFileContent(patchedPluginXml.value, """
-            <idea-plugin>
-              <version>0.42.123</version>
-              <change-notes>change notes</change-notes>
-              <idea-version since-build="141.1532" until-build="141.*" />
-            </idea-plugin>
-        """)
-
-        assertFalse(output.contains("will be overwritten"))
+            assertNotContains("will be overwritten", it.output)
+        }
     }
 
     @Test
@@ -141,17 +152,20 @@ class PatchPluginXmlTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val output = build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).output
+        build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).let {
+            assertFileContent(
+                patchedPluginXml.value,
+                """
+                    <idea-plugin>
+                      <id>my.plugin.id</id>
+                      <version>0.42.123</version>
+                      <idea-version since-build="141.1532" until-build="141.*" />
+                    </idea-plugin>
+                """
+            )
 
-        assertFileContent(patchedPluginXml.value, """
-            <idea-plugin>
-              <id>my.plugin.id</id>
-              <version>0.42.123</version>
-              <idea-version since-build="141.1532" until-build="141.*" />
-            </idea-plugin>
-        """)
-
-        assertFalse(output.contains("will be overwritten"))
+            assertNotContains("will be overwritten", it.output)
+        }
     }
 
     @Test
@@ -170,18 +184,21 @@ class PatchPluginXmlTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val output = build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).output
+        build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).let {
+            assertFileContent(
+                patchedPluginXml.value,
+                """
+                    <idea-plugin>
+                      <version>0.42.123</version>
+                      <idea-version since-build="141.1532" until-build="141.*" />
+                      <id>my.plugin.id</id>
+                      <vendor>JetBrains</vendor>
+                    </idea-plugin>
+                """
+            )
 
-        assertFileContent(patchedPluginXml.value, """
-            <idea-plugin>
-              <version>0.42.123</version>
-              <idea-version since-build="141.1532" until-build="141.*" />
-              <id>my.plugin.id</id>
-              <vendor>JetBrains</vendor>
-            </idea-plugin>
-        """)
-
-        assertFalse(output.contains("will be overwritten"))
+            assertNotContains("will be overwritten", it.output)
+        }
     }
 
     @Test
@@ -198,15 +215,19 @@ class PatchPluginXmlTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val output = build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).output
-        assertFileContent(patchedPluginXml.value, """
-            <idea-plugin>
-              <version>0.42.123</version>
-              <idea-version since-build="141.1532" until-build="141.1532.*" />
-            </idea-plugin>
-        """)
+        build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).let {
+            assertFileContent(
+                patchedPluginXml.value,
+                """
+                    <idea-plugin>
+                      <version>0.42.123</version>
+                      <idea-version since-build="141.1532" until-build="141.1532.*" />
+                    </idea-plugin>
+                """
+            )
 
-        assertFalse(output.contains("will be overwritten"))
+            assertNotContains("will be overwritten", it.output)
+        }
     }
 
     @Test
@@ -225,16 +246,21 @@ class PatchPluginXmlTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val output = build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).output
-        assertFileContent(patchedPluginXml.value, """
-            <idea-plugin>
-              <version>0.42.123</version>
-              <idea-version since-build="141.1532" until-build="141.*" />
-              <id>org.jetbrains.erlang</id>
-              <vendor>JetBrains</vendor>
-            </idea-plugin>
-        """)
-        assertFalse(output.contains("will be overwritten"))
+        build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).let {
+            assertFileContent(
+                patchedPluginXml.value,
+                """
+                    <idea-plugin>
+                      <version>0.42.123</version>
+                      <idea-version since-build="141.1532" until-build="141.*" />
+                      <id>org.jetbrains.erlang</id>
+                      <vendor>JetBrains</vendor>
+                    </idea-plugin>
+                """
+            )
+
+            assertNotContains("will be overwritten", it.output)
+        }
     }
 
     @Test
@@ -254,18 +280,22 @@ class PatchPluginXmlTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val output = build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).output
-        assertFileContent(patchedPluginXml.value, """
-            <idea-plugin>
-              <version>0.42.123</version>
-              <idea-version since-build="141.1532" until-build="141.*">my_version</idea-version>
-              <vendor>JetBrains</vendor>
-            </idea-plugin>
-        """)
+        build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).let {
+            assertFileContent(
+                patchedPluginXml.value,
+                """
+                    <idea-plugin>
+                      <version>0.42.123</version>
+                      <idea-version since-build="141.1532" until-build="141.*">my_version</idea-version>
+                      <vendor>JetBrains</vendor>
+                    </idea-plugin>
+                """
+            )
 
-        assertTrue(output.contains("attribute 'since-build=[1]' of 'idea-version' tag will be set to '141.1532'"))
-        assertTrue(output.contains("attribute 'until-build=[2]' of 'idea-version' tag will be set to '141.*'"))
-        assertTrue(output.contains("value of 'version[my_version]' tag will be set to '0.42.123'"))
+            assertContains("attribute 'since-build=[1]' of 'idea-version' tag will be set to '141.1532'", it.output)
+            assertContains("attribute 'until-build=[2]' of 'idea-version' tag will be set to '141.*'", it.output)
+            assertContains("value of 'version[my_version]' tag will be set to '0.42.123'", it.output)
+        }
     }
 
     @Test
@@ -285,15 +315,19 @@ class PatchPluginXmlTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val output = build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).output
+        build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).let {
+            assertFileContent(
+                patchedPluginXml.value,
+                """
+                    <idea-plugin>
+                      <version>0.42.123</version>
+                      <idea-version since-build="1" until-build="2">my_version</idea-version>
+                    </idea-plugin>
+                """
+            )
 
-        assertFileContent(patchedPluginXml.value, """
-            <idea-plugin>
-              <version>0.42.123</version>
-              <idea-version since-build="1" until-build="2">my_version</idea-version>
-            </idea-plugin>
-        """)
-        assertFalse(output.contains("will be overwritten"))
+            assertNotContains("will be overwritten", it.output)
+        }
     }
 
     @Test
@@ -310,15 +344,19 @@ class PatchPluginXmlTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val output = build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).output
+        build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).let {
+            assertFileContent(
+                patchedPluginXml.value,
+                """
+                    <idea-plugin>
+                      <idea-version since-build="141.1532" until-build="141.*" />
+                      <version>0.10.0</version>
+                    </idea-plugin>
+                """
+            )
 
-        assertFileContent(patchedPluginXml.value, """
-            <idea-plugin>
-              <idea-version since-build="141.1532" until-build="141.*" />
-              <version>0.10.0</version>
-            </idea-plugin>
-        """)
-        assertFalse(output.contains("will be overwritten"))
+            assertNotContains("will be overwritten", it.output)
+        }
     }
 
     @Test
@@ -335,15 +373,18 @@ class PatchPluginXmlTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME)
-        val result = build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME)
-
-        assertEquals(TaskOutcome.UP_TO_DATE, result.task(":${IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME}")?.outcome)
-        assertFileContent(patchedPluginXml.value, """
-            <idea-plugin>
-              <version>0.42.123</version>
-              <idea-version since-build="141.1532" until-build="141.*" />
-            </idea-plugin>
-        """)
+        build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).let {
+            assertEquals(TaskOutcome.UP_TO_DATE, it.task(":${IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME}")?.outcome)
+            assertFileContent(
+                patchedPluginXml.value,
+                """
+                    <idea-plugin>
+                      <version>0.42.123</version>
+                      <idea-version since-build="141.1532" until-build="141.*" />
+                    </idea-plugin>
+                """
+            )
+        }
     }
 
     @Test
@@ -367,15 +408,18 @@ class PatchPluginXmlTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME)
-
-        assertNotEquals(TaskOutcome.UP_TO_DATE, result.task(":${IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME}")?.outcome)
-        assertFileContent(patchedPluginXml.value, """
-            <idea-plugin>
-              <version>0.42.123</version>
-              <idea-version since-build="141.1532" until-build="141.*" />
-            </idea-plugin>
-        """)
+        build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME).let {
+            assertNotEquals(TaskOutcome.UP_TO_DATE, it.task(":${IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME}")?.outcome)
+            assertFileContent(
+                patchedPluginXml.value,
+                """
+                    <idea-plugin>
+                      <version>0.42.123</version>
+                      <idea-version since-build="141.1532" until-build="141.*" />
+                    </idea-plugin>
+                """
+            )
+        }
     }
 
 
@@ -393,7 +437,8 @@ class PatchPluginXmlTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME, "--configuration-cache")
-        val result = build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME, "--configuration-cache")
-        assertContains("Reusing configuration cache.", result.output)
+        build(IntelliJPluginConstants.PATCH_PLUGIN_XML_TASK_NAME, "--configuration-cache").let {
+            assertContains("Reusing configuration cache.", it.output)
+        }
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/PrepareSandboxTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/PrepareSandboxTaskSpec.kt
@@ -826,8 +826,7 @@ class PrepareSandboxTaskSpec : IntelliJPluginSpecBase() {
 
         build(IntelliJPluginConstants.PREPARE_SANDBOX_TASK_NAME, "--configuration-cache", "--info")
         val result = build(IntelliJPluginConstants.PREPARE_SANDBOX_TASK_NAME, "--configuration-cache")
-
-        assertTrue(result.output.contains("Reusing configuration cache."))
+        assertContains("Reusing configuration cache.", result.output)
     }
 
     @Test
@@ -847,8 +846,7 @@ class PrepareSandboxTaskSpec : IntelliJPluginSpecBase() {
 
         build(IntelliJPluginConstants.PREPARE_TESTING_SANDBOX_TASK_NAME, "--configuration-cache", "--info")
         val result = build(IntelliJPluginConstants.PREPARE_TESTING_SANDBOX_TASK_NAME, "--configuration-cache")
-
-        assertTrue(result.output.contains("Reusing configuration cache."))
+        assertContains("Reusing configuration cache.", result.output)
     }
 
     @Test
@@ -883,7 +881,6 @@ class PrepareSandboxTaskSpec : IntelliJPluginSpecBase() {
 
         build(IntelliJPluginConstants.PREPARE_UI_TESTING_SANDBOX_TASK_NAME, "--configuration-cache", "--info")
         val result = build(IntelliJPluginConstants.PREPARE_UI_TESTING_SANDBOX_TASK_NAME, "--configuration-cache")
-
-        assertTrue(result.output.contains("Reusing configuration cache."))
+        assertContains("Reusing configuration cache.", result.output)
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/PrepareSandboxTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/PrepareSandboxTaskSpec.kt
@@ -11,7 +11,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-@Suppress("GroovyUnusedAssignment", "PluginXmlValidity")
+@Suppress("GroovyUnusedAssignment", "PluginXmlValidity", "ComplexRedundantLet")
 class PrepareSandboxTaskSpec : IntelliJPluginSpecBase() {
 
     private val sandbox = File(buildDirectory, IntelliJPluginConstants.DEFAULT_SANDBOX)
@@ -411,24 +411,24 @@ class PrepareSandboxTaskSpec : IntelliJPluginSpecBase() {
         )
     }
 
-    private fun createPlugin(): File {
-        val plugin = createTempDirectory("tmp").toFile()
-        File(plugin, "classes/").mkdir()
-        File(plugin, "META-INF/").mkdir()
-        File(plugin, "classes/A.class").createNewFile()
-        File(plugin, "classes/someResources.properties").createNewFile()
-        File(plugin, "META-INF/plugin.xml").xml("""
-            <idea-plugin>
-              <id>${plugin.name}</id>
-              <name>Test</name>
-              <version>1.0</version>
-              <idea-version since-build="212.5712" until-build="212.*" />
-              <vendor url="https://jetbrains.com">JetBrains</vendor>
-              <description>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</description>
-              <change-notes/>
-            </idea-plugin>
-        """)
-        return plugin
+    private fun createPlugin() = createTempDirectory("tmp").toFile().also {
+        File(it, "classes/").mkdir()
+        File(it, "META-INF/").mkdir()
+        File(it, "classes/A.class").createNewFile()
+        File(it, "classes/someResources.properties").createNewFile()
+        File(it, "META-INF/plugin.xml").xml(
+            """
+                <idea-plugin>
+                  <id>${it.name}</id>
+                  <name>Test</name>
+                  <version>1.0</version>
+                  <idea-version since-build="212.5712" until-build="212.*" />
+                  <vendor url="https://jetbrains.com">JetBrains</vendor>
+                  <description>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</description>
+                  <change-notes/>
+                </idea-plugin>
+            """
+        )
     }
 
     @Test
@@ -825,8 +825,9 @@ class PrepareSandboxTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         build(IntelliJPluginConstants.PREPARE_SANDBOX_TASK_NAME, "--configuration-cache", "--info")
-        val result = build(IntelliJPluginConstants.PREPARE_SANDBOX_TASK_NAME, "--configuration-cache")
-        assertContains("Reusing configuration cache.", result.output)
+        build(IntelliJPluginConstants.PREPARE_SANDBOX_TASK_NAME, "--configuration-cache").let {
+            assertContains("Reusing configuration cache.", it.output)
+        }
     }
 
     @Test
@@ -845,8 +846,9 @@ class PrepareSandboxTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         build(IntelliJPluginConstants.PREPARE_TESTING_SANDBOX_TASK_NAME, "--configuration-cache", "--info")
-        val result = build(IntelliJPluginConstants.PREPARE_TESTING_SANDBOX_TASK_NAME, "--configuration-cache")
-        assertContains("Reusing configuration cache.", result.output)
+        build(IntelliJPluginConstants.PREPARE_TESTING_SANDBOX_TASK_NAME, "--configuration-cache").let {
+            assertContains("Reusing configuration cache.", it.output)
+        }
     }
 
     @Test
@@ -880,7 +882,8 @@ class PrepareSandboxTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         build(IntelliJPluginConstants.PREPARE_UI_TESTING_SANDBOX_TASK_NAME, "--configuration-cache", "--info")
-        val result = build(IntelliJPluginConstants.PREPARE_UI_TESTING_SANDBOX_TASK_NAME, "--configuration-cache")
-        assertContains("Reusing configuration cache.", result.output)
+        build(IntelliJPluginConstants.PREPARE_UI_TESTING_SANDBOX_TASK_NAME, "--configuration-cache").let {
+            assertContains("Reusing configuration cache.", it.output)
+        }
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/ProcessResourcesTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/ProcessResourcesTaskSpec.kt
@@ -10,7 +10,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
-@Suppress("GroovyUnusedAssignment", "PluginXmlValidity")
+@Suppress("GroovyUnusedAssignment", "PluginXmlValidity", "ComplexRedundantLet")
 class ProcessResourcesTaskSpec : IntelliJPluginSpecBase() {
 
     private val outputPluginXml = lazy { File(buildDirectory, "resources/main/META-INF/").listFiles()?.first() }
@@ -38,12 +38,12 @@ class ProcessResourcesTaskSpec : IntelliJPluginSpecBase() {
 
         build(JavaPlugin.PROCESS_RESOURCES_TASK_NAME)
 
-        val result = build(JavaPlugin.PROCESS_RESOURCES_TASK_NAME)
-
-        assertEquals(
-            TaskOutcome.UP_TO_DATE,
-            result.task(":${JavaPlugin.PROCESS_RESOURCES_TASK_NAME}")?.outcome,
-        )
+        build(JavaPlugin.PROCESS_RESOURCES_TASK_NAME).let {
+            assertEquals(
+                TaskOutcome.UP_TO_DATE,
+                it.task(":${JavaPlugin.PROCESS_RESOURCES_TASK_NAME}")?.outcome,
+            )
+        }
     }
 
     @Test
@@ -62,18 +62,21 @@ class ProcessResourcesTaskSpec : IntelliJPluginSpecBase() {
             patchPluginXml { sinceBuild = 'Oh' }
         """)
 
-        val result = build(JavaPlugin.PROCESS_RESOURCES_TASK_NAME)
+        build(JavaPlugin.PROCESS_RESOURCES_TASK_NAME).let {
+            assertNotEquals(
+                TaskOutcome.UP_TO_DATE,
+                it.task(":${JavaPlugin.PROCESS_RESOURCES_TASK_NAME}")?.outcome,
+            )
 
-        assertNotEquals(
-            TaskOutcome.UP_TO_DATE,
-            result.task(":${JavaPlugin.PROCESS_RESOURCES_TASK_NAME}")?.outcome,
-        )
-
-        assertFileContent(outputPluginXml.value, """
-            <idea-plugin>
-              <version>0.42.123</version>
-              <idea-version since-build="Oh" until-build="212.*" />
-            </idea-plugin>
-        """)
+            assertFileContent(
+                outputPluginXml.value,
+                """
+                    <idea-plugin>
+                      <version>0.42.123</version>
+                      <idea-version since-build="Oh" until-build="212.*" />
+                    </idea-plugin>
+                """
+            )
+        }
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/PublishPluginTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/PublishPluginTaskSpec.kt
@@ -6,7 +6,6 @@ import org.jetbrains.intellij.IntelliJPluginConstants
 import org.jetbrains.intellij.IntelliJPluginSpecBase
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
 class PublishPluginTaskSpec : IntelliJPluginSpecBase() {
 
@@ -34,8 +33,7 @@ class PublishPluginTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = buildAndFail(IntelliJPluginConstants.PUBLISH_PLUGIN_TASK_NAME)
-
-        assertTrue(result.output.contains("token property must be specified for plugin publishing"))
+        assertContains("token property must be specified for plugin publishing", result.output)
     }
 
     @Test
@@ -49,7 +47,6 @@ class PublishPluginTaskSpec : IntelliJPluginSpecBase() {
 
         buildAndFail(IntelliJPluginConstants.PUBLISH_PLUGIN_TASK_NAME, "--configuration-cache")
         val result = buildAndFail(IntelliJPluginConstants.PUBLISH_PLUGIN_TASK_NAME, "--configuration-cache")
-
-        assertTrue(result.output.contains("Reusing configuration cache."))
+        assertContains("Reusing configuration cache.", result.output)
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/PublishPluginTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/PublishPluginTaskSpec.kt
@@ -7,6 +7,7 @@ import org.jetbrains.intellij.IntelliJPluginSpecBase
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
+@Suppress("ComplexRedundantLet")
 class PublishPluginTaskSpec : IntelliJPluginSpecBase() {
 
     @BeforeTest
@@ -32,8 +33,9 @@ class PublishPluginTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = buildAndFail(IntelliJPluginConstants.PUBLISH_PLUGIN_TASK_NAME)
-        assertContains("token property must be specified for plugin publishing", result.output)
+        buildAndFail(IntelliJPluginConstants.PUBLISH_PLUGIN_TASK_NAME).let {
+            assertContains("token property must be specified for plugin publishing", it.output)
+        }
     }
 
     @Test
@@ -46,7 +48,8 @@ class PublishPluginTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         buildAndFail(IntelliJPluginConstants.PUBLISH_PLUGIN_TASK_NAME, "--configuration-cache")
-        val result = buildAndFail(IntelliJPluginConstants.PUBLISH_PLUGIN_TASK_NAME, "--configuration-cache")
-        assertContains("Reusing configuration cache.", result.output)
+        buildAndFail(IntelliJPluginConstants.PUBLISH_PLUGIN_TASK_NAME, "--configuration-cache").let {
+            assertContains("Reusing configuration cache.", it.output)
+        }
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTaskSpec.kt
@@ -7,8 +7,6 @@ import org.jetbrains.intellij.IntelliJPluginConstants
 import org.jetbrains.intellij.IntelliJPluginSpecBase
 import java.net.URL
 import kotlin.test.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 @Suppress("GroovyUnusedAssignment", "PluginXmlValidity")
 class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
@@ -26,8 +24,7 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-
-        assertContains( "Starting the IntelliJ Plugin Verifier 1.255", result.output)
+        assertContains( "Starting the IntelliJ Plugin Verifier 1.2551", result.output)
     }
 
     @Test
@@ -43,7 +40,6 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-
         assertContains( "Could not find org.jetbrains.intellij.plugins:verifier-cli:1.254", result.output)
     }
 
@@ -76,7 +72,6 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-
         assertContains( "Plugin MyName:1.0.0 against IC-202.7660.26: Compatible", result.output)
         assertContains( "Plugin MyName:1.0.0 against PS-201.8538.41: Compatible", result.output)
     }
@@ -94,7 +89,6 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-
         assertContains( "Plugin MyName:1.0.0 against AI-211.7628.21.2111.7824002: Compatible", result.output)
     }
 
@@ -112,7 +106,6 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-
         val directory = file("build/foo").canonicalPath
         assertContains( "Verification reports directory: $directory", result.output)
     }
@@ -137,7 +130,6 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-
         assertContains( "> Task :listProductsReleases", result.output)
         assertContains( "Starting the IntelliJ Plugin Verifier", result.output)
     }
@@ -157,7 +149,6 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-
         assertContains( "> Task :listProductsReleases SKIPPED", result.output)
     }
 
@@ -170,7 +161,6 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-
         assertContains( "Plugin descriptor 'plugin.xml' is not found", result.output)
         assertContains( "Task :verifyPlugin FAILED", result.output)
     }
@@ -191,7 +181,6 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-
         assertContains( "Deprecated API usages", result.output)
         assertContains( "org.gradle.api.GradleException: DEPRECATED_API_USAGES", result.output)
     }
@@ -209,7 +198,6 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-
         assertContains( "Deprecated API usages", result.output)
         assertNotContains( "org.gradle.api.GradleException: DEPRECATED_API_USAGES", result.output)
     }
@@ -229,7 +217,6 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-
         assertContains( "IDE 'foo' cannot be downloaded.", result.output)
     }
 
@@ -249,7 +236,6 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-
         assertContains( "Deprecated API usages", result.output)
         assertContains( "org.gradle.api.GradleException: DEPRECATED_API_USAGES", result.output)
     }
@@ -270,7 +256,6 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-
         assertContains( "Deprecated API usages", result.output)
         assertNotContains("org.gradle.api.GradleException: DEPRECATED_API_USAGES", result.output)
     }
@@ -311,7 +296,6 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
 
         build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME, "--configuration-cache")
         val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME, "--configuration-cache")
-
         assertContains( "Reusing configuration cache.", result.output)
     }
 
@@ -350,32 +334,5 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
                 <depends>com.intellij.modules.platform</depends>
             </idea-plugin>
         """)
-    }
-
-    companion object {
-        private fun assertContains(
-                expected: String,
-                actual: String,
-        ) {
-            // https://stackoverflow.com/questions/10934743/formatting-output-so-that-intellij-idea-shows-diffs-for-two-texts
-            assertTrue(
-                actual.contains(expected),
-                """
-                    expected:<$expected> but was:<$actual>
-                """.trimIndent()
-            )
-        }
-        private fun assertNotContains(
-                expected: String,
-                actual: String,
-        ) {
-            // https://stackoverflow.com/questions/10934743/formatting-output-so-that-intellij-idea-shows-diffs-for-two-texts
-            assertFalse(
-                actual.contains(expected),
-                """
-                    expected:<$expected> but was:<$actual>
-                """.trimIndent()
-            )
-        }
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTaskSpec.kt
@@ -27,7 +27,7 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
 
         val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
 
-        assertTrue(result.output.contains("Starting the IntelliJ Plugin Verifier 1.255"))
+        assertContains( "Starting the IntelliJ Plugin Verifier 1.255", result.output)
     }
 
     @Test
@@ -44,7 +44,7 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
 
         val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
 
-        assertTrue(result.output.contains("Could not find org.jetbrains.intellij.plugins:verifier-cli:1.254"))
+        assertContains( "Could not find org.jetbrains.intellij.plugins:verifier-cli:1.254", result.output)
     }
 
     @Test
@@ -60,7 +60,7 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
 
         val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
         val version = RunPluginVerifierTask.resolveLatestVersion()
-        assertTrue(result.output.contains("Starting the IntelliJ Plugin Verifier $version"))
+        assertContains( "Starting the IntelliJ Plugin Verifier $version", result.output)
     }
 
     @Test
@@ -77,8 +77,8 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
 
         val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
 
-        assertTrue(result.output.contains("Plugin MyName:1.0.0 against IC-202.7660.26: Compatible"))
-        assertTrue(result.output.contains("Plugin MyName:1.0.0 against PS-201.8538.41: Compatible"))
+        assertContains( "Plugin MyName:1.0.0 against IC-202.7660.26: Compatible", result.output)
+        assertContains( "Plugin MyName:1.0.0 against PS-201.8538.41: Compatible", result.output)
     }
 
     @Test
@@ -95,7 +95,7 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
 
         val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
 
-        assertTrue(result.output.contains("Plugin MyName:1.0.0 against AI-211.7628.21.2111.7824002: Compatible"))
+        assertContains( "Plugin MyName:1.0.0 against AI-211.7628.21.2111.7824002: Compatible", result.output)
     }
 
     @Test
@@ -114,7 +114,7 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
 
         val directory = file("build/foo").canonicalPath
-        assertTrue(result.output.contains("Verification reports directory: $directory"))
+        assertContains( "Verification reports directory: $directory", result.output)
     }
 
     @Test
@@ -138,8 +138,8 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
 
         val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
 
-        assertTrue(result.output.contains("> Task :listProductsReleases"))
-        assertTrue(result.output.contains("Starting the IntelliJ Plugin Verifier"))
+        assertContains( "> Task :listProductsReleases", result.output)
+        assertContains( "Starting the IntelliJ Plugin Verifier", result.output)
     }
 
     @Test
@@ -158,7 +158,7 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
 
         val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
 
-        assertTrue(result.output.contains("> Task :listProductsReleases SKIPPED"))
+        assertContains( "> Task :listProductsReleases SKIPPED", result.output)
     }
 
     @Test
@@ -171,8 +171,8 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
 
         val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
 
-        assertTrue(result.output.contains("Plugin descriptor 'plugin.xml' is not found"))
-        assertTrue(result.output.contains("Task :verifyPlugin FAILED"))
+        assertContains( "Plugin descriptor 'plugin.xml' is not found", result.output)
+        assertContains( "Task :verifyPlugin FAILED", result.output)
     }
 
     @Test
@@ -192,8 +192,8 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
 
         val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
 
-        assertTrue(result.output.contains("Deprecated API usages"))
-        assertTrue(result.output.contains("org.gradle.api.GradleException: DEPRECATED_API_USAGES"))
+        assertContains( "Deprecated API usages", result.output)
+        assertContains( "org.gradle.api.GradleException: DEPRECATED_API_USAGES", result.output)
     }
 
     @Test
@@ -210,8 +210,8 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
 
         val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
 
-        assertTrue(result.output.contains("Deprecated API usages"))
-        assertFalse(result.output.contains("org.gradle.api.GradleException: DEPRECATED_API_USAGES"))
+        assertContains( "Deprecated API usages", result.output)
+        assertNotContains( "org.gradle.api.GradleException: DEPRECATED_API_USAGES", result.output)
     }
 
     @Test
@@ -230,7 +230,7 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
 
         val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
 
-        assertTrue(result.output.contains("IDE 'foo' cannot be downloaded."))
+        assertContains( "IDE 'foo' cannot be downloaded.", result.output)
     }
 
     @Test
@@ -250,8 +250,8 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
 
         val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
 
-        assertTrue(result.output.contains("Deprecated API usages"))
-        assertTrue(result.output.contains("org.gradle.api.GradleException: DEPRECATED_API_USAGES"))
+        assertContains( "Deprecated API usages", result.output)
+        assertContains( "org.gradle.api.GradleException: DEPRECATED_API_USAGES", result.output)
     }
 
     @Test
@@ -271,8 +271,8 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
 
         val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
 
-        assertTrue(result.output.contains("Deprecated API usages"))
-        assertFalse(result.output.contains("org.gradle.api.GradleException: DEPRECATED_API_USAGES"))
+        assertContains( "Deprecated API usages", result.output)
+        assertNotContains("org.gradle.api.GradleException: DEPRECATED_API_USAGES", result.output)
     }
 
     @Test
@@ -295,7 +295,7 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
             }
 
         val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME, "--offline")
-        assertTrue(result.output.contains("Gradle runs in offline mode."))
+        assertContains( "Gradle runs in offline mode.", result.output)
     }
 
     @Test
@@ -312,7 +312,7 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME, "--configuration-cache")
         val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME, "--configuration-cache")
 
-        assertTrue(result.output.contains("Reusing configuration cache."))
+        assertContains( "Reusing configuration cache.", result.output)
     }
 
     private fun warmupGradle() {
@@ -350,5 +350,32 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
                 <depends>com.intellij.modules.platform</depends>
             </idea-plugin>
         """)
+    }
+
+    companion object {
+        private fun assertContains(
+                expected: String,
+                actual: String,
+        ) {
+            // https://stackoverflow.com/questions/10934743/formatting-output-so-that-intellij-idea-shows-diffs-for-two-texts
+            assertTrue(
+                actual.contains(expected),
+                """
+                    expected:<$expected> but was:<$actual>
+                """.trimIndent()
+            )
+        }
+        private fun assertNotContains(
+                expected: String,
+                actual: String,
+        ) {
+            // https://stackoverflow.com/questions/10934743/formatting-output-so-that-intellij-idea-shows-diffs-for-two-texts
+            assertFalse(
+                actual.contains(expected),
+                """
+                    expected:<$expected> but was:<$actual>
+                """.trimIndent()
+            )
+        }
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTaskSpec.kt
@@ -8,7 +8,7 @@ import org.jetbrains.intellij.IntelliJPluginSpecBase
 import java.net.URL
 import kotlin.test.Test
 
-@Suppress("GroovyUnusedAssignment", "PluginXmlValidity")
+@Suppress("GroovyUnusedAssignment", "PluginXmlValidity", "ComplexRedundantLet")
 class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
 
     @Test
@@ -23,8 +23,9 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-        assertContains( "Starting the IntelliJ Plugin Verifier 1.2551", result.output)
+        build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME).let {
+            assertContains("Starting the IntelliJ Plugin Verifier 1.255", it.output)
+        }
     }
 
     @Test
@@ -39,8 +40,9 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-        assertContains( "Could not find org.jetbrains.intellij.plugins:verifier-cli:1.254", result.output)
+        buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME).let {
+            assertContains("Could not find org.jetbrains.intellij.plugins:verifier-cli:1.254", it.output)
+        }
     }
 
     @Test
@@ -54,9 +56,10 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-        val version = RunPluginVerifierTask.resolveLatestVersion()
-        assertContains( "Starting the IntelliJ Plugin Verifier $version", result.output)
+        build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME).let {
+            val version = RunPluginVerifierTask.resolveLatestVersion()
+            assertContains("Starting the IntelliJ Plugin Verifier $version", it.output)
+        }
     }
 
     @Test
@@ -71,9 +74,10 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-        assertContains( "Plugin MyName:1.0.0 against IC-202.7660.26: Compatible", result.output)
-        assertContains( "Plugin MyName:1.0.0 against PS-201.8538.41: Compatible", result.output)
+        build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME).let {
+            assertContains("Plugin MyName:1.0.0 against IC-202.7660.26: Compatible", it.output)
+            assertContains("Plugin MyName:1.0.0 against PS-201.8538.41: Compatible", it.output)
+        }
     }
 
     @Test
@@ -88,8 +92,9 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-        assertContains( "Plugin MyName:1.0.0 against AI-211.7628.21.2111.7824002: Compatible", result.output)
+        build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME).let {
+            assertContains("Plugin MyName:1.0.0 against AI-211.7628.21.2111.7824002: Compatible", it.output)
+        }
     }
 
     @Test
@@ -105,9 +110,10 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-        val directory = file("build/foo").canonicalPath
-        assertContains( "Verification reports directory: $directory", result.output)
+        build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME).let {
+            val directory = file("build/foo").canonicalPath
+            assertContains("Verification reports directory: $directory", it.output)
+        }
     }
 
     @Test
@@ -129,9 +135,10 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-        assertContains( "> Task :listProductsReleases", result.output)
-        assertContains( "Starting the IntelliJ Plugin Verifier", result.output)
+        build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME).let {
+            assertContains("> Task :listProductsReleases", it.output)
+            assertContains("Starting the IntelliJ Plugin Verifier", it.output)
+        }
     }
 
     @Test
@@ -148,8 +155,9 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-        assertContains( "> Task :listProductsReleases SKIPPED", result.output)
+        buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME).let {
+            assertContains("> Task :listProductsReleases SKIPPED", it.output)
+        }
     }
 
     @Test
@@ -160,9 +168,10 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
             version = "1.0.0"
         """)
 
-        val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-        assertContains( "Plugin descriptor 'plugin.xml' is not found", result.output)
-        assertContains( "Task :verifyPlugin FAILED", result.output)
+        buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME).let {
+            assertContains("Plugin descriptor 'plugin.xml' is not found", it.output)
+            assertContains("Task :verifyPlugin FAILED", it.output)
+        }
     }
 
     @Test
@@ -180,9 +189,10 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-        assertContains( "Deprecated API usages", result.output)
-        assertContains( "org.gradle.api.GradleException: DEPRECATED_API_USAGES", result.output)
+        buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME).let {
+            assertContains("Deprecated API usages", it.output)
+            assertContains("org.gradle.api.GradleException: DEPRECATED_API_USAGES", it.output)
+        }
     }
 
     @Test
@@ -197,9 +207,10 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-        assertContains( "Deprecated API usages", result.output)
-        assertNotContains( "org.gradle.api.GradleException: DEPRECATED_API_USAGES", result.output)
+        build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME).let {
+            assertContains("Deprecated API usages", it.output)
+            assertNotContains("org.gradle.api.GradleException: DEPRECATED_API_USAGES", it.output)
+        }
     }
 
     @Test
@@ -216,8 +227,9 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-        assertContains( "IDE 'foo' cannot be downloaded.", result.output)
+        buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME).let {
+            assertContains("IDE 'foo' cannot be downloaded.", it.output)
+        }
     }
 
     @Test
@@ -235,9 +247,10 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-        assertContains( "Deprecated API usages", result.output)
-        assertContains( "org.gradle.api.GradleException: DEPRECATED_API_USAGES", result.output)
+        buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME).let {
+            assertContains("Deprecated API usages", it.output)
+            assertContains("org.gradle.api.GradleException: DEPRECATED_API_USAGES", it.output)
+        }
     }
 
     @Test
@@ -255,9 +268,10 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME)
-        assertContains( "Deprecated API usages", result.output)
-        assertNotContains("org.gradle.api.GradleException: DEPRECATED_API_USAGES", result.output)
+        build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME).let {
+            assertContains("Deprecated API usages", it.output)
+            assertNotContains("org.gradle.api.GradleException: DEPRECATED_API_USAGES", it.output)
+        }
     }
 
     @Test
@@ -279,8 +293,9 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
                 FileUtils.copyInputStreamToFile(it, file("build/pluginVerifier.jar"))
             }
 
-        val result = buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME, "--offline")
-        assertContains( "Gradle runs in offline mode.", result.output)
+        buildAndFail(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME, "--offline").let {
+            assertContains("Gradle runs in offline mode.", it.output)
+        }
     }
 
     @Test
@@ -295,8 +310,9 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME, "--configuration-cache")
-        val result = build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME, "--configuration-cache")
-        assertContains( "Reusing configuration cache.", result.output)
+        build(IntelliJPluginConstants.RUN_PLUGIN_VERIFIER_TASK_NAME, "--configuration-cache").let {
+            assertContains("Reusing configuration cache.", it.output)
+        }
     }
 
     private fun warmupGradle() {

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/SignPluginTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/SignPluginTaskSpec.kt
@@ -6,10 +6,9 @@ import org.jetbrains.intellij.IntelliJPluginConstants
 import org.jetbrains.intellij.IntelliJPluginSpecBase
 import java.io.File
 import kotlin.test.Test
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-@Suppress("GroovyUnusedAssignment")
+@Suppress("GroovyUnusedAssignment", "ComplexRedundantLet")
 class SignPluginTaskSpec : IntelliJPluginSpecBase() {
 
     @Test
@@ -24,8 +23,9 @@ class SignPluginTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val version = SignPluginTask.resolveLatestVersion()
-        val result = build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME, "--info")
-        assertContains("marketplace-zip-signer-cli-$version.jar", result.output)
+        build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME, "--info").let {
+            assertContains("marketplace-zip-signer-cli-$version.jar", it.output)
+        }
     }
 
     @Test
@@ -40,8 +40,9 @@ class SignPluginTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME, "--info")
-        assertContains("marketplace-zip-signer-cli-0.1.7.jar", result.output)
+        build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME, "--info").let {
+            assertContains("marketplace-zip-signer-cli-0.1.7.jar", it.output)
+        }
     }
 
     @Test
@@ -50,8 +51,9 @@ class SignPluginTaskSpec : IntelliJPluginSpecBase() {
             version = "1.0.0"
         """)
 
-        val result = build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME)
-        assertContains("Task :${IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME} SKIPPED", result.output)
+        build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME).let {
+            assertContains("Task :${IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME} SKIPPED", it.output)
+        }
     }
 
     @Test
@@ -64,8 +66,9 @@ class SignPluginTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = buildAndFail(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME)
-        assertContains("Could not find org.jetbrains:marketplace-zip-signer-cli:0.0.1.", result.output)
+        buildAndFail(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME).let {
+            assertContains("Could not find org.jetbrains:marketplace-zip-signer-cli:0.0.1.", it.output)
+        }
     }
 
     @Test
@@ -89,17 +92,17 @@ class SignPluginTaskSpec : IntelliJPluginSpecBase() {
     @Test
     fun `reuse configuration cache`() {
         build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME, "--configuration-cache")
-        val result = build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME, "--configuration-cache")
-        assertContains("Reusing configuration cache.", result.output)
+        build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME, "--configuration-cache").let {
+            assertContains("Reusing configuration cache.", it.output)
+        }
     }
 
     @Test
     fun `ignore cache when optional parameter changes`() {
         build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME, "--configuration-cache")
-        assertTrue(
-            build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME, "--configuration-cache")
-                .output.contains("Reusing configuration cache.")
-        )
+        build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME, "--configuration-cache").let {
+            assertContains("Reusing configuration cache.", it.output)
+        }
 
         buildFile.groovy("""
             version = "1.0.0"
@@ -108,10 +111,10 @@ class SignPluginTaskSpec : IntelliJPluginSpecBase() {
                 password = "foo"
             }
         """)
-        assertFalse(
-            build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME, "--configuration-cache")
-                .output.contains("Reusing configuration cache.")
-        )
+
+        build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME, "--configuration-cache").let {
+            assertNotContains("Reusing configuration cache.", it.output)
+        }
     }
 
     private fun loadCertFile(name: String) = javaClass.classLoader.getResource(name)?.path

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/SignPluginTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/SignPluginTaskSpec.kt
@@ -25,8 +25,7 @@ class SignPluginTaskSpec : IntelliJPluginSpecBase() {
 
         val version = SignPluginTask.resolveLatestVersion()
         val result = build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME, "--info")
-
-        assertTrue(result.output.contains("marketplace-zip-signer-cli-$version.jar"))
+        assertContains("marketplace-zip-signer-cli-$version.jar", result.output)
     }
 
     @Test
@@ -42,8 +41,7 @@ class SignPluginTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME, "--info")
-
-        assertTrue(result.output.contains("marketplace-zip-signer-cli-0.1.7.jar"))
+        assertContains("marketplace-zip-signer-cli-0.1.7.jar", result.output)
     }
 
     @Test
@@ -53,8 +51,7 @@ class SignPluginTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME)
-
-        assertTrue(result.output.contains("Task :${IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME} SKIPPED"))
+        assertContains("Task :${IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME} SKIPPED", result.output)
     }
 
     @Test
@@ -68,8 +65,7 @@ class SignPluginTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = buildAndFail(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME)
-
-        assertTrue(result.output.contains("Could not find org.jetbrains:marketplace-zip-signer-cli:0.0.1."))
+        assertContains("Could not find org.jetbrains:marketplace-zip-signer-cli:0.0.1.", result.output)
     }
 
     @Test
@@ -94,8 +90,7 @@ class SignPluginTaskSpec : IntelliJPluginSpecBase() {
     fun `reuse configuration cache`() {
         build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME, "--configuration-cache")
         val result = build(IntelliJPluginConstants.SIGN_PLUGIN_TASK_NAME, "--configuration-cache")
-
-        assertTrue(result.output.contains("Reusing configuration cache."))
+        assertContains("Reusing configuration cache.", result.output)
     }
 
     @Test

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/VerifyPluginConfigurationTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/VerifyPluginConfigurationTaskSpec.kt
@@ -5,8 +5,6 @@ package org.jetbrains.intellij.tasks
 import org.jetbrains.intellij.IntelliJPluginConstants
 import org.jetbrains.intellij.IntelliJPluginSpecBase
 import kotlin.test.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 @Suppress("PluginXmlCapitalization", "PluginXmlValidity")
 class VerifyPluginConfigurationTaskSpec : IntelliJPluginSpecBase() {
@@ -27,8 +25,7 @@ class VerifyPluginConfigurationTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME)
-
-        assertFalse(result.output.contains(HEADER))
+        assertNotContains(HEADER, result.output)
     }
 
     @Test
@@ -49,9 +46,8 @@ class VerifyPluginConfigurationTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME)
-
-        assertTrue(result.output.contains(HEADER))
-        assertTrue(result.output.contains("- The 'since-build' property is lower than the target IntelliJ Platform major version: 211 < 212."))
+        assertContains(HEADER, result.output)
+        assertContains("- The 'since-build' property is lower than the target IntelliJ Platform major version: 211 < 212.", result.output)
     }
 
     @Test
@@ -61,9 +57,8 @@ class VerifyPluginConfigurationTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME)
-
-        assertTrue(result.output.contains(HEADER))
-        assertTrue(result.output.contains("- The Java configuration specifies sourceCompatibility=1.8 but IntelliJ Platform 2021.2.4 requires sourceCompatibility=11."))
+        assertContains(HEADER, result.output)
+        assertContains("- The Java configuration specifies sourceCompatibility=1.8 but IntelliJ Platform 2021.2.4 requires sourceCompatibility=11.", result.output)
     }
 
     @Test
@@ -73,9 +68,8 @@ class VerifyPluginConfigurationTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME)
-
-        assertTrue(result.output.contains(HEADER))
-        assertTrue(result.output.contains("- The Java configuration specifies targetCompatibility=17 but IntelliJ Platform 2021.2.4 requires targetCompatibility=11."))
+        assertContains(HEADER, result.output)
+        assertContains("- The Java configuration specifies targetCompatibility=17 but IntelliJ Platform 2021.2.4 requires targetCompatibility=11.", result.output)
     }
 
     @Test
@@ -89,9 +83,8 @@ class VerifyPluginConfigurationTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME)
-
-        assertTrue(result.output.contains(HEADER))
-        assertTrue(result.output.contains("- The Kotlin configuration specifies jvmTarget=17 but IntelliJ Platform 2021.2.4 requires jvmTarget=11."))
+        assertContains(HEADER, result.output)
+        assertContains("- The Kotlin configuration specifies jvmTarget=17 but IntelliJ Platform 2021.2.4 requires jvmTarget=11.", result.output)
     }
 
     @Test
@@ -114,9 +107,8 @@ class VerifyPluginConfigurationTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME)
-
-        assertTrue(result.output.contains(HEADER))
-        assertTrue(result.output.contains("- The Kotlin configuration specifies apiVersion=1.9 but since-build='212.5712' property requires apiVersion=1.5.10."))
+        assertContains(HEADER, result.output)
+        assertContains("- The Kotlin configuration specifies apiVersion=1.9 but since-build='212.5712' property requires apiVersion=1.5.10.", result.output)
     }
 
     @Test
@@ -130,9 +122,8 @@ class VerifyPluginConfigurationTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME)
-
-        assertTrue(result.output.contains(HEADER))
-        assertTrue(result.output.contains("- The Kotlin configuration specifies languageVersion=1.3 but IntelliJ Platform 2021.2.4 requires languageVersion=1.5.10."))
+        assertContains(HEADER, result.output)
+        assertContains("- The Kotlin configuration specifies languageVersion=1.3 but IntelliJ Platform 2021.2.4 requires languageVersion=1.5.10.", result.output)
     }
 
     @Test
@@ -141,8 +132,8 @@ class VerifyPluginConfigurationTaskSpec : IntelliJPluginSpecBase() {
         gradleProperties.writeText("")
 
         build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME).let { result ->
-            assertTrue(result.output.contains(HEADER))
-            assertTrue(result.output.contains("- The dependency on the Kotlin Standard Library (stdlib) is automatically added when using the Gradle Kotlin plugin and may conflict with the version provided with the IntelliJ Platform, see: https://jb.gg/intellij-platform-kotlin-stdlib"))
+            assertContains(HEADER, result.output)
+            assertContains("- The dependency on the Kotlin Standard Library (stdlib) is automatically added when using the Gradle Kotlin plugin and may conflict with the version provided with the IntelliJ Platform, see: https://jb.gg/intellij-platform-kotlin-stdlib", result.output)
         }
 
         gradleProperties.properties(
@@ -152,7 +143,7 @@ class VerifyPluginConfigurationTaskSpec : IntelliJPluginSpecBase() {
         )
 
         build("clean", IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME).let { result ->
-            assertFalse(result.output.contains(HEADER))
+            assertNotContains(HEADER, result.output)
         }
 
         gradleProperties.properties(
@@ -162,7 +153,7 @@ class VerifyPluginConfigurationTaskSpec : IntelliJPluginSpecBase() {
         )
 
         build("clean", IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME).let { result ->
-            assertFalse(result.output.contains(HEADER))
+            assertNotContains(HEADER, result.output)
         }
     }
 
@@ -170,7 +161,6 @@ class VerifyPluginConfigurationTaskSpec : IntelliJPluginSpecBase() {
     fun `reuse configuration cache`() {
         build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME, "--configuration-cache")
         val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME, "--configuration-cache")
-
-        assertTrue(result.output.contains("Reusing configuration cache."))
+        assertContains("Reusing configuration cache.", result.output)
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/VerifyPluginConfigurationTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/VerifyPluginConfigurationTaskSpec.kt
@@ -6,124 +6,158 @@ import org.jetbrains.intellij.IntelliJPluginConstants
 import org.jetbrains.intellij.IntelliJPluginSpecBase
 import kotlin.test.Test
 
-@Suppress("PluginXmlCapitalization", "PluginXmlValidity")
+@Suppress("PluginXmlCapitalization", "PluginXmlValidity", "ComplexRedundantLet")
 class VerifyPluginConfigurationTaskSpec : IntelliJPluginSpecBase() {
 
     companion object {
         const val HEADER = "The following plugin configuration issues were found"
     }
-    
+
     @Test
     fun `do not show errors when configuration is valid`() {
-        pluginXml.xml("""
+        pluginXml.xml(
+            """
             <idea-plugin>
                 <name>PluginName</name>
                 <description>Lorem ipsum.</description>
                 <vendor>JetBrains</vendor>
                 <idea-version since-build="212" until-build='212.*' />
             </idea-plugin>
-        """)
+        """
+        )
 
-        val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME)
-        assertNotContains(HEADER, result.output)
+        build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME).let {
+            assertNotContains(HEADER, it.output)
+        }
     }
 
     @Test
     fun `report too low since-build`() {
-        buildFile.groovy("""
+        buildFile.groovy(
+            """
             patchPluginXml {
                 sinceBuild = "211"
             }
-        """)
+        """
+        )
 
-        pluginXml.xml("""
+        pluginXml.xml(
+            """
             <idea-plugin>
                 <name>PluginName</name>
                 <description>Lorem ipsum.</description>
                 <vendor>JetBrains</vendor>
                 <idea-version since-build="211" until-build='212.*' />
             </idea-plugin>
-        """)
+        """
+        )
 
-        val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME)
-        assertContains(HEADER, result.output)
-        assertContains("- The 'since-build' property is lower than the target IntelliJ Platform major version: 211 < 212.", result.output)
+        build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME).let {
+            assertContains(HEADER, it.output)
+            assertContains("- The 'since-build' property is lower than the target IntelliJ Platform major version: 211 < 212.", it.output)
+        }
     }
 
     @Test
     fun `report too low Java sourceCompatibility`() {
-        buildFile.groovy("""
+        buildFile.groovy(
+            """
             sourceCompatibility = 1.8
-        """)
+        """
+        )
 
-        val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME)
-        assertContains(HEADER, result.output)
-        assertContains("- The Java configuration specifies sourceCompatibility=1.8 but IntelliJ Platform 2021.2.4 requires sourceCompatibility=11.", result.output)
+        build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME).let {
+            assertContains(HEADER, it.output)
+            assertContains(
+                "- The Java configuration specifies sourceCompatibility=1.8 but IntelliJ Platform 2021.2.4 requires sourceCompatibility=11.",
+                it.output
+            )
+        }
     }
 
     @Test
     fun `report too high Java targetCompatibility`() {
-        buildFile.groovy("""
+        buildFile.groovy(
+            """
             targetCompatibility = 17
-        """)
+        """
+        )
 
-        val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME)
-        assertContains(HEADER, result.output)
-        assertContains("- The Java configuration specifies targetCompatibility=17 but IntelliJ Platform 2021.2.4 requires targetCompatibility=11.", result.output)
+        build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME).let {
+            assertContains(HEADER, it.output)
+            assertContains(
+                "- The Java configuration specifies targetCompatibility=17 but IntelliJ Platform 2021.2.4 requires targetCompatibility=11.",
+                it.output
+            )
+        }
     }
 
     @Test
     fun `report too high Kotlin jvmTarget`() {
-        buildFile.groovy("""
+        buildFile.groovy(
+            """
             compileKotlin {
                 kotlinOptions {
                     jvmTarget = "17"
                 }
             }
-        """)
+        """
+        )
 
-        val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME)
-        assertContains(HEADER, result.output)
-        assertContains("- The Kotlin configuration specifies jvmTarget=17 but IntelliJ Platform 2021.2.4 requires jvmTarget=11.", result.output)
+        build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME).let {
+            assertContains(HEADER, it.output)
+            assertContains("- The Kotlin configuration specifies jvmTarget=17 but IntelliJ Platform 2021.2.4 requires jvmTarget=11.", it.output)
+        }
     }
 
     @Test
     fun `report too high Kotlin apiVersion`() {
-        pluginXml.xml("""
+        pluginXml.xml(
+            """
             <idea-plugin>
                 <name>PluginName</name>
                 <description>Lorem ipsum.</description>
                 <vendor>JetBrains</vendor>
                 <idea-version since-build="211" until-build='212.*' />
             </idea-plugin>
-        """)
+        """
+        )
 
-        buildFile.groovy("""
+        buildFile.groovy(
+            """
             compileKotlin {
                 kotlinOptions {
                     apiVersion = "1.9"
                 }
             }
-        """)
+        """
+        )
 
-        val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME)
-        assertContains(HEADER, result.output)
-        assertContains("- The Kotlin configuration specifies apiVersion=1.9 but since-build='212.5712' property requires apiVersion=1.5.10.", result.output)
+        build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME).let {
+            assertContains(HEADER, it.output)
+            assertContains("- The Kotlin configuration specifies apiVersion=1.9 but since-build='212.5712' property requires apiVersion=1.5.10.", it.output)
+        }
     }
 
     @Test
     fun `report too low Kotlin languageVersion`() {
-        buildFile.groovy("""
+        buildFile.groovy(
+            """
             compileKotlin {
                 kotlinOptions {
                     languageVersion = "1.3"
                 }
             }
-        """)
+        """
+        )
 
-        val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME)
-        assertContains(HEADER, result.output)
-        assertContains("- The Kotlin configuration specifies languageVersion=1.3 but IntelliJ Platform 2021.2.4 requires languageVersion=1.5.10.", result.output)
+        build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME).let {
+            assertContains(HEADER, it.output)
+            assertContains(
+                "- The Kotlin configuration specifies languageVersion=1.3 but IntelliJ Platform 2021.2.4 requires languageVersion=1.5.10.",
+                it.output
+            )
+        }
     }
 
     @Test
@@ -131,9 +165,12 @@ class VerifyPluginConfigurationTaskSpec : IntelliJPluginSpecBase() {
         // kotlin.stdlib.default.dependency gets unset
         gradleProperties.writeText("")
 
-        build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME).let { result ->
-            assertContains(HEADER, result.output)
-            assertContains("- The dependency on the Kotlin Standard Library (stdlib) is automatically added when using the Gradle Kotlin plugin and may conflict with the version provided with the IntelliJ Platform, see: https://jb.gg/intellij-platform-kotlin-stdlib", result.output)
+        build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME).let {
+            assertContains(HEADER, it.output)
+            assertContains(
+                "- The dependency on the Kotlin Standard Library (stdlib) is automatically added when using the Gradle Kotlin plugin and may conflict with the version provided with the IntelliJ Platform, see: https://jb.gg/intellij-platform-kotlin-stdlib",
+                it.output
+            )
         }
 
         gradleProperties.properties(
@@ -160,7 +197,8 @@ class VerifyPluginConfigurationTaskSpec : IntelliJPluginSpecBase() {
     @Test
     fun `reuse configuration cache`() {
         build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME, "--configuration-cache")
-        val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME, "--configuration-cache")
-        assertContains("Reusing configuration cache.", result.output)
+        build(IntelliJPluginConstants.VERIFY_PLUGIN_CONFIGURATION_TASK_NAME, "--configuration-cache").let {
+            assertContains("Reusing configuration cache.", it.output)
+        }
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/VerifyPluginTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/VerifyPluginTaskSpec.kt
@@ -5,8 +5,6 @@ package org.jetbrains.intellij.tasks
 import org.jetbrains.intellij.IntelliJPluginConstants
 import org.jetbrains.intellij.IntelliJPluginSpecBase
 import kotlin.test.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 @Suppress("PluginXmlCapitalization", "PluginXmlValidity")
 class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
@@ -26,8 +24,7 @@ class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-
-        assertTrue(result.output.contains("Plugin name specified in plugin.xml should not contain the word 'plugin'"))
+        assertContains("Plugin name specified in plugin.xml should not contain the word 'plugin'", result.output)
     }
 
     @Test
@@ -49,8 +46,7 @@ class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = buildAndFail(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-
-        assertTrue(result.output.contains("Plugin name specified in plugin.xml should not contain the word 'IntelliJ'"))
+        assertContains("Plugin name specified in plugin.xml should not contain the word 'IntelliJ'", result.output)
     }
 
     @Test
@@ -68,8 +64,7 @@ class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = buildAndFail(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-
-        assertTrue(result.output.contains("Description is too short"))
+        assertContains("Description is too short", result.output)
     }
 
     @Test
@@ -91,15 +86,13 @@ class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-
-        assertTrue(result.output.contains("Description is too short"))
+        assertContains("Description is too short", result.output)
     }
 
     @Test
     fun `fail on errors by default`() {
         val result = buildAndFail(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-
-        result.output.contains("Plugin descriptor 'plugin.xml' is not found")
+        assertContains("Plugin descriptor 'plugin.xml' is not found", result.output)
     }
 
     @Test
@@ -111,8 +104,7 @@ class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-
-        result.output.contains("Plugin descriptor 'plugin.xml' is not found")
+        assertContains("Plugin descriptor 'plugin.xml' is not found", result.output)
     }
 
     @Test
@@ -134,8 +126,7 @@ class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = buildAndFail(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-
-        result.output.contains("<name> must not be equal to default value:")
+        assertContains("<name> must not be equal to default value:", result.output)
     }
 
     @Test
@@ -157,8 +148,7 @@ class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-
-        result.output.contains("Description is too short")
+        assertContains("Description is too short", result.output)
     }
 
     @Test
@@ -181,15 +171,13 @@ class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
         """)
 
         val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-
-        assertFalse(result.output.contains("Plugin verification"))
+        assertNotContains("Plugin verification", result.output)
     }
 
     @Test
     fun `reuse configuration cache`() {
         buildAndFail(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME, "--configuration-cache")
         val result = buildAndFail(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME, "--configuration-cache")
-
-        assertTrue(result.output.contains("Reusing configuration cache."))
+        assertContains("Reusing configuration cache.", result.output)
     }
 }

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/VerifyPluginTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/VerifyPluginTaskSpec.kt
@@ -6,7 +6,7 @@ import org.jetbrains.intellij.IntelliJPluginConstants
 import org.jetbrains.intellij.IntelliJPluginSpecBase
 import kotlin.test.Test
 
-@Suppress("PluginXmlCapitalization", "PluginXmlValidity")
+@Suppress("PluginXmlCapitalization", "PluginXmlValidity", "ComplexRedundantLet")
 class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
 
     @Test
@@ -23,8 +23,9 @@ class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
             </idea-plugin>
         """)
 
-        val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-        assertContains("Plugin name specified in plugin.xml should not contain the word 'plugin'", result.output)
+        build(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME).let {
+            assertContains("Plugin name specified in plugin.xml should not contain the word 'plugin'", it.output)
+        }
     }
 
     @Test
@@ -45,8 +46,9 @@ class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
             </idea-plugin>
         """)
 
-        val result = buildAndFail(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-        assertContains("Plugin name specified in plugin.xml should not contain the word 'IntelliJ'", result.output)
+        buildAndFail(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME).let {
+            assertContains("Plugin name specified in plugin.xml should not contain the word 'IntelliJ'", it.output)
+        }
     }
 
     @Test
@@ -63,8 +65,9 @@ class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
             </idea-plugin>
         """)
 
-        val result = buildAndFail(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-        assertContains("Description is too short", result.output)
+        buildAndFail(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME).let {
+            assertContains("Description is too short", it.output)
+        }
     }
 
     @Test
@@ -85,14 +88,17 @@ class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
             </idea-plugin>
         """)
 
-        val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-        assertContains("Description is too short", result.output)
+        build(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME).let {
+            assertContains("Description is too short", it.output)
+        }
     }
 
     @Test
     fun `fail on errors by default`() {
-        val result = buildAndFail(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-        assertContains("Plugin descriptor 'plugin.xml' is not found", result.output)
+        pluginXml.delete()
+        buildAndFail(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME).let {
+            assertContains("Plugin descriptor 'plugin.xml' is not found", it.output)
+        }
     }
 
     @Test
@@ -103,8 +109,10 @@ class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
             }
         """)
 
-        val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-        assertContains("Plugin descriptor 'plugin.xml' is not found", result.output)
+        pluginXml.delete()
+        build(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME).let {
+            assertContains("Plugin descriptor 'plugin.xml' is not found", it.output)
+        }
     }
 
     @Test
@@ -125,8 +133,9 @@ class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
             </idea-plugin>
         """)
 
-        val result = buildAndFail(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-        assertContains("<name> must not be equal to default value:", result.output)
+        buildAndFail(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME).let {
+            assertContains("<name> must not be equal to default value:", it.output)
+        }
     }
 
     @Test
@@ -147,8 +156,9 @@ class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
             </idea-plugin>
         """)
 
-        val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-        assertContains("Description is too short", result.output)
+        build(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME).let {
+            assertContains("Description is too short", it.output)
+        }
     }
 
     @Test
@@ -170,14 +180,16 @@ class VerifyPluginTaskSpec : IntelliJPluginSpecBase() {
             </idea-plugin>
         """)
 
-        val result = build(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME)
-        assertNotContains("Plugin verification", result.output)
+        build(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME).let {
+            assertNotContains("Plugin verification", it.output)
+        }
     }
 
     @Test
     fun `reuse configuration cache`() {
         buildAndFail(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME, "--configuration-cache")
-        val result = buildAndFail(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME, "--configuration-cache")
-        assertContains("Reusing configuration cache.", result.output)
+        buildAndFail(IntelliJPluginConstants.VERIFY_PLUGIN_TASK_NAME, "--configuration-cache").let {
+            assertContains("Reusing configuration cache.", it.output)
+        }
     }
 }


### PR DESCRIPTION
add messages to test assertions, so the failure reason is easier to see in CI 

## Related Issue

Helps see failures in #1120 

## Motivation and Context

It's not clear why the tests here are failing 
https://github.com/aSemy/gradle-intellij-plugin/actions/runs/3131999575/jobs/5083926495

## How Has This Been Tested


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGES.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
