### PR TITLE
Improve usage of project.layout, and use provider.map{} more

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
@@ -14,11 +14,13 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.file.RegularFile
 import org.gradle.api.internal.artifacts.publish.ArchivePublishArtifact
 import org.gradle.api.internal.plugins.DefaultArtifactPublicationSet
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.PluginInstantiationException
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.ClasspathNormalizer
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceSetContainer
@@ -340,9 +342,7 @@ abstract class IntelliJPlugin : Plugin<Project> {
             pluginXmlFiles.convention(project.provider {
                 sourcePluginXmlFiles(project)
             })
-            destinationDir.convention(project.layout.dir(project.provider {
-                File(project.buildDir, PLUGIN_XML_DIR_NAME)
-            }))
+            destinationDir.convention(project.layout.buildDirectory.dir(PLUGIN_XML_DIR_NAME))
             outputFiles.convention(pluginXmlFiles.map {
                 it.map { file ->
                     destinationDir.get().asFile.resolve(file.name)
@@ -392,9 +392,7 @@ abstract class IntelliJPlugin : Plugin<Project> {
             description = "Download `robot-server` plugin."
 
             version.convention(VERSION_LATEST)
-            outputDir.convention(project.provider {
-                project.layout.projectDirectory.dir("${project.buildDir}/robotServerPlugin")
-            })
+            outputDir.convention(project.layout.buildDirectory.dir("robotServerPlugin"))
             pluginArchive.convention(project.provider {
                 val resolvedVersion = resolveRobotServerPluginVersion(version.orNull)
                 val (group, name) = getDependency(resolvedVersion).split(':')
@@ -505,12 +503,10 @@ abstract class IntelliJPlugin : Plugin<Project> {
 
             failureLevel.convention(EnumSet.of(RunPluginVerifierTask.FailureLevel.COMPATIBILITY_PROBLEMS))
             verifierVersion.convention(VERSION_LATEST)
-            distributionFile.convention(project.layout.file(project.provider {
-                resolveBuildTaskOutput(project)
-            }))
-            verificationReportsDir.convention(project.provider {
-                "${project.buildDir}/reports/pluginVerifier"
-            })
+            distributionFile.convention(resolveBuildTaskOutput(project))
+            verificationReportsDir.convention(
+                project.layout.buildDirectory.dir("reports/pluginVerifier").map { it.asFile.canonicalPath }
+            )
             downloadDir.convention(ideDownloadDir().map {
                 it.toFile().invariantSeparatorsPath
             })
@@ -621,11 +617,16 @@ abstract class IntelliJPlugin : Plugin<Project> {
             ignoreFailures.convention(false)
             ignoreUnacceptableWarnings.convention(false)
             ignoreWarnings.convention(true)
-            pluginDir.convention(project.provider {
-                val prepareSandboxTask = prepareSandboxTaskProvider.get()
-                val path = File(prepareSandboxTask.destinationDir, prepareSandboxTask.pluginName.get()).path
-                project.layout.projectDirectory.dir(path)
-            })
+
+            pluginDir.convention(
+                project.layout.dir(
+                    prepareSandboxTaskProvider.flatMap { prepareSandboxTask ->
+                        prepareSandboxTask.pluginName.map { pluginName ->
+                            prepareSandboxTask.destinationDir.resolve(pluginName)
+                        }
+                    }
+                )
+            )
 
             dependsOn(PREPARE_SANDBOX_TASK_NAME)
         }
@@ -770,9 +771,7 @@ abstract class IntelliJPlugin : Plugin<Project> {
             group = PLUGIN_GROUP_NAME
             description = "Builds an index of UI components (searchable options) for the plugin."
 
-            outputDir.convention(project.provider {
-                project.layout.projectDirectory.dir("${project.buildDir}/$SEARCHABLE_OPTIONS_DIR_NAME")
-            })
+            outputDir.convention(project.layout.buildDirectory.dir(SEARCHABLE_OPTIONS_DIR_NAME))
             showPaidPluginWarning.convention(project.provider {
                 project.isBuildFeatureEnabled(PAID_PLUGIN_SEARCHABLE_OPTIONS_WARNING) && run {
                     sourcePluginXmlFiles(project).any {
@@ -844,9 +843,7 @@ abstract class IntelliJPlugin : Plugin<Project> {
             group = PLUGIN_GROUP_NAME
             description = "Creates a JAR file with searchable options to be distributed with the plugin."
 
-            outputDir.convention(project.provider {
-                project.layout.projectDirectory.dir(project.buildDir.resolve(SEARCHABLE_OPTIONS_DIR_NAME).canonicalPath)
-            })
+            outputDir.convention(project.layout.buildDirectory.dir(SEARCHABLE_OPTIONS_DIR_NAME))
             pluginName.convention(prepareSandboxTaskProvider.get().pluginName)
             sandboxDir.convention(project.provider {
                 prepareSandboxTaskProvider.get().destinationDir.canonicalPath
@@ -1219,9 +1216,7 @@ abstract class IntelliJPlugin : Plugin<Project> {
             group = PLUGIN_GROUP_NAME
             description = "Signs the ZIP archive with the provided key using marketplace-zip-signer library."
 
-            inputArchiveFile.convention(project.layout.file(project.provider {
-                resolveBuildTaskOutput(project)
-            }))
+            inputArchiveFile.convention(resolveBuildTaskOutput(project))
             outputArchiveFile.convention(project.layout.file(project.provider {
                 val inputFile = buildPluginTaskProvider.get().archiveFile.get().asFile
                 val inputFileExtension = inputFile.path.substring(inputFile.path.lastIndexOf('.'))
@@ -1266,10 +1261,12 @@ abstract class IntelliJPlugin : Plugin<Project> {
             host.convention(MARKETPLACE_HOST)
             toolboxEnterprise.convention(false)
             channels.convention(listOf("default"))
-            distributionFile.convention(project.layout.file(project.provider {
-                val signPluginTask = signPluginTaskProvider.get()
-                signPluginTask.outputArchiveFile.orNull?.asFile.takeIf { signPluginTask.didWork } ?: resolveBuildTaskOutput(project)
-            }))
+
+            distributionFile.convention(
+                signPluginTaskProvider.flatMap { signPluginTask ->
+                    signPluginTask.outputArchiveFile
+                }.orElse(resolveBuildTaskOutput(project))
+            )
 
             dependsOn(BUILD_PLUGIN_TASK_NAME)
             dependsOn(VERIFY_PLUGIN_TASK_NAME)
@@ -1490,10 +1487,9 @@ abstract class IntelliJPlugin : Plugin<Project> {
         }
     }
 
-    private fun resolveBuildTaskOutput(project: Project): File? {
-        val buildPluginTaskProvider = project.tasks.named<Zip>(BUILD_PLUGIN_TASK_NAME)
-        val buildPluginTask = buildPluginTaskProvider.get()
-        return buildPluginTask.archiveFile.orNull?.asFile?.takeIf { it.exists() }
+    private fun resolveBuildTaskOutput(project: Project): Provider<RegularFile> {
+        return project.tasks.named<Zip>(BUILD_PLUGIN_TASK_NAME)
+            .flatMap { it.archiveFile }
     }
 
     private fun getCurrentVersion() = IntelliJPlugin::class.java


### PR DESCRIPTION
part of #1114 

tidy up usage of layout.buildDirectory, and try to use .map {} to help Gradle providers connect task inputs/outputs better

I might be wrong but using 

```kotlin
project.provider { 
  val task = taskProvider.get()
  task.outputFile
}
```

means Gradle loses the connection between the task and the file.

On the other hand, 

```kotlin
taskProvider.map { task -> task.outputFile }
```

means that Gradle can determine that `task` *must* run in order to provide the file, and so Gradle will automatically run that task whenever the value of provider is requested.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGES.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
