### PR TITLE
Disable the scheduled nightly release GHA on forks

### DIFF
--- a/.github/workflows/release-nightly-scheduled.yml
+++ b/.github/workflows/release-nightly-scheduled.yml
@@ -11,5 +11,5 @@ on:
 jobs:
 
   release-nightly:
-    if: contains("JetBrains/gradle-intellij-plugin", github.repository)
+    if: contains('JetBrains/gradle-intellij-plugin', github.repository)
     uses: ./.github/workflows/release-nightly.yml

--- a/.github/workflows/release-nightly-scheduled.yml
+++ b/.github/workflows/release-nightly-scheduled.yml
@@ -1,0 +1,15 @@
+name: Nightly Release (scheduled)
+
+# Automatically run the release-nightly job
+#
+# The scheduled release will be disabled on forks, preventing unnecessary work.
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+
+  release-nightly:
+    if: contains("JetBrains/gradle-intellij-plugin", github.repository)
+    uses: ./.github/workflows/release-nightly.yml

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -7,6 +7,7 @@ on:
         required: false
         default: false
         type: boolean
+  workflow_call:
 
 env:
   XDG_CACHE_HOME: "~/.config/"

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -7,8 +7,6 @@ on:
         required: false
         default: false
         type: boolean
-  schedule:
-    - cron: "0 0 * * *"
 
 env:
   XDG_CACHE_HOME: "~/.config/"


### PR DESCRIPTION
# Pull Request Details

Since GitHub does not provide a nice option for disable scheduled jobs on forks, I've instead split out the nightly-release task from the scheduler. This means only one `if: contains("JetBrains/gradle-intellij-plugin", github.repository)` is required - otherwise it would have to be defined on _all_ jobs in the `release-nightly.yml`, which is difficult to maintain

## Related Issue

fix #1132

## Motivation and Context

save energy 🌳 

## How Has This Been Tested

I've merged it into the master of my fork, so I'll see if it works tonight (I expect the nightly-release workflow *won't* run).

https://github.com/JetBrains/gradle-intellij-plugin/compare/master...aSemy:gradle-intellij-plugin:master

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGES.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
