### PR TITLE
Fix failing Gradle 6.8 compat test

### DIFF
--- a/src/test/kotlin/org/jetbrains/intellij/IntelliJPluginSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/IntelliJPluginSpec.kt
@@ -554,21 +554,63 @@ class IntelliJPluginSpec : IntelliJPluginSpecBase() {
     }
 
     @Test
-    fun `throws exception if Gradle is lt 6_8`() {
-        val message = "Gradle IntelliJ Plugin requires Gradle $MINIMAL_SUPPORTED_GRADLE_VERSION and higher"
+    fun `expect build fails when using unsupported Gradle version`() {
+        val unsupportedGradleVersions = setOf(
+            "6.4",
+            "6.7.1",
+        )
 
-        build("6.4", true, "help").output.let {
-            assertTrue(it.contains("FAILURE: Build failed with an exception."))
+        unsupportedGradleVersions.forEach { gradleVersion ->
+            build(gradleVersion, true, "help").apply {
+                assertContains("Gradle IntelliJ Plugin requires Gradle", output)
+                assertContains("FAILURE: Build failed with an exception", output)
+            }
         }
+    }
 
-        build("6.7.1", true, "help").output.let {
-            assertTrue(it.contains("FAILURE: Build failed with an exception."))
-        }
+    /**
+     * Note: An older version of `kotlin("jvm")` is because 1.7.+ requires Gradle 7.1.
+     *
+     * (specifically `kotlin("jvm")` requires the method [org.gradle.api.plugins.JavaPluginExtension.getSourceSets])
+     */
+    @Test
+    fun `expect successful build using minimal supported Gradle version`() {
 
-        build(MINIMAL_SUPPORTED_GRADLE_VERSION, false, "help").output.let {
-            assertTrue(it.contains("BUILD SUCCESSFUL"))
-            assertFalse(it.contains(message))
-        }
+        buildFile.writeText("") // reset the build file - need to apply an older version of Kotlin plugin
+        buildFile.groovy(
+            """
+            plugins {
+                id 'org.jetbrains.intellij'
+                id 'org.jetbrains.kotlin.jvm' version '1.4.0' 
+            }
+            sourceCompatibility = 11
+            targetCompatibility = 11
+            repositories {
+                mavenCentral()
+            }
+            intellij {
+                version = '$intellijVersion'
+                downloadSources = false
+                pluginsRepositories {
+                    maven('$pluginsRepository')
+                }
+                instrumentCode = false
+            }
+            buildSearchableOptions {
+                enabled = false
+            }
+            
+            // Define tasks with a minimal set of tasks required to build a source set
+            sourceSets.all {
+                task(it.getTaskName('build', 'SourceSet'), dependsOn: it.output)
+            }
+        """.trimIndent()
+        )
+
+        val buildResult = build(MINIMAL_SUPPORTED_GRADLE_VERSION, false, "help")
+
+        assertContains("BUILD SUCCESSFUL", buildResult.output)
+        assertNotContains("Gradle IntelliJ Plugin requires Gradle", buildResult.output)
     }
 
     @SuppressWarnings("GrEqualsBetweenInconvertibleTypes")

--- a/src/test/kotlin/org/jetbrains/intellij/IntelliJPluginSpecBase.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/IntelliJPluginSpecBase.kt
@@ -36,15 +36,17 @@ abstract class IntelliJPluginSpecBase {
         ?: throw GradleException("'test.intellij.version' isn't provided")
     val testMarkdownPluginVersion = System.getProperty("test.markdownPlugin.version").takeUnless { it.isNullOrEmpty() }
         ?: throw GradleException("'test.markdownPlugin.version' isn't provided")
-    val dir: File by lazy { createTempDirectory("tmp").toFile() }
+    var dir: File = createTempDirectory("tmp").toFile()
 
-    val gradleProperties = file("gradle.properties")
-    val buildFile = file("build.gradle")
-    val pluginXml = file("src/main/resources/META-INF/plugin.xml")
-    val buildDirectory = File(dir, "build")
+    val gradleProperties get() = file("gradle.properties")
+    val buildFile get() = file("build.gradle")
+    val pluginXml get() = file("src/main/resources/META-INF/plugin.xml")
+    val buildDirectory get() = File(dir, "build")
 
     @BeforeTest
     open fun setUp() {
+        dir = createTempDirectory("tmp").toFile()
+
         file("settings.gradle").groovy("rootProject.name = 'projectName'")
 
         buildFile.groovy(

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/PrepareSandboxTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/PrepareSandboxTaskSpec.kt
@@ -577,7 +577,7 @@ class PrepareSandboxTaskSpec : IntelliJPluginSpecBase() {
                 <option name="CHECK_NEEDED" value="false" />
               </component>
             </application>
-            """,
+            """.trimIndent(),
         )
     }
 
@@ -613,7 +613,7 @@ class PrepareSandboxTaskSpec : IntelliJPluginSpecBase() {
                 <option name="CHECK_NEEDED" value="false" />
               </component>
             </application>
-            """,
+            """.trimIndent(),
         )
     }
 
@@ -647,7 +647,7 @@ class PrepareSandboxTaskSpec : IntelliJPluginSpecBase() {
                 <option name="CHECK_NEEDED" value="false" />
               </component>
             </application>
-            """,
+            """.trimIndent(),
         )
     }
 
@@ -681,7 +681,7 @@ class PrepareSandboxTaskSpec : IntelliJPluginSpecBase() {
                 <option name="CHECK_NEEDED" value="false" />
               </component>
             </application>
-            """,
+            """.trimIndent(),
         )
     }
 
@@ -715,7 +715,7 @@ class PrepareSandboxTaskSpec : IntelliJPluginSpecBase() {
                 <option name="CHECK_NEEDED" value="false" />
               </component>
             </application>
-            """,
+            """.trimIndent(),
         )
     }
 
@@ -741,7 +741,7 @@ class PrepareSandboxTaskSpec : IntelliJPluginSpecBase() {
                 <option name="CHECK_NEEDED" value="false" />
               </component>
             </application>
-            """,
+            """.trimIndent(),
         )
     }
 
@@ -801,7 +801,7 @@ class PrepareSandboxTaskSpec : IntelliJPluginSpecBase() {
                 <option name="CHECK_NEEDED" value="false" />
               </component>
             </application>
-            """,
+            """.trimIndent(),
         )
     }
 

--- a/src/test/kotlin/org/jetbrains/intellij/tasks/PrepareSandboxTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/PrepareSandboxTaskSpec.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertTrue
 @Suppress("GroovyUnusedAssignment", "PluginXmlValidity", "ComplexRedundantLet")
 class PrepareSandboxTaskSpec : IntelliJPluginSpecBase() {
 
-    private val sandbox = File(buildDirectory, DEFAULT_SANDBOX)
+    private val sandbox get() = File(buildDirectory, DEFAULT_SANDBOX)
 
     @Test
     fun `prepare sandbox for two plugins`() {


### PR DESCRIPTION
# Pull Request Details

This test has been failing

https://github.com/JetBrains/gradle-intellij-plugin/blob/7f0c94e042a8a8408a85f5708a1956ac53349a76/src/test/kotlin/org/jetbrains/intellij/IntelliJPluginSpec.kt#L556-L572

To see the report, download the test report https://github.com/JetBrains/gradle-intellij-plugin/actions/runs/3162489793#artifacts

Or see this screenshot:

<img width="1169" alt="image" src="https://user-images.githubusercontent.com/897017/193401596-3c10caaa-99e7-4cc3-b462-5c28876e1fc3.png">

```none
throws exception if Gradle is lt 6_8
org.gradle.testkit.runner.UnexpectedBuildFailure: Unexpected build execution failure in /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmp14084314477339985448 with arguments [help, --stacktrace, --configuration-cache]

Output:
Configuration cache is an incubating feature.
Calculating task graph as no configuration cache is available for tasks: help

> Configure project :
[gradle-intellij-plugin :projectName] Gradle IntelliJ Plugin is outdated: 0.0.0. Update `org.jetbrains.intellij` to: 1.9.0

FAILURE: Build failed with an exception.

* What went wrong:
'org.gradle.api.tasks.SourceSetContainer org.gradle.api.plugins.JavaPluginExtension.getSourceSets()'

* Try:
Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Exception is:
java.lang.NoSuchMethodError: 'org.gradle.api.tasks.SourceSetContainer org.gradle.api.plugins.JavaPluginExtension.getSourceSets()'
	at org.jetbrains.kotlin.gradle.plugin.internal.DefaultJavaSourceSetsAccessor.getSourceSets(JavaSourceSetsAccessor.kt:34)
	at org.jetbrains.kotlin.gradle.plugin.AbstractKotlinPlugin$Companion.setUpJavaSourceSets$kotlin_gradle_plugin_common(KotlinPlugin.kt:501)
	at org.jetbrains.kotlin.gradle.plugin.AbstractKotlinPlugin$Companion.setUpJavaSourceSets$kotlin_gradle_plugin_common$default(KotlinPlugin.kt:492)
	at org.jetbrains.kotlin.gradle.plugin.AbstractKotlinPlugin$Companion.configureTarget(KotlinPlugin.kt:487)
	at org.jetbrains.kotlin.gradle.plugin.AbstractKotlinPlugin.apply(KotlinPlugin.kt:382)
	at org.jetbrains.kotlin.gradle.plugin.KotlinPlugin.apply(KotlinPlugin.kt:621)
	at org.jetbrains.kotlin.gradle.plugin.KotlinPlugin.apply(KotlinPlugin.kt:595)
	at org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper.apply(KotlinPluginWrapper.kt:183)
	at org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper.apply(PluginWrappers.kt:27)
	at org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper.apply(PluginWrappers.kt:19)
	at org.gradle.api.internal.plugins.ImperativeOnlyPluginTarget.applyImperative(ImperativeOnlyPluginTarget.java:43)
```

## Description

1. split up less-than/equal-to minimum supported Gradle version tests (easier to see test failures)
2. update test to use older version of Kotlin plugin (for more info see the KDoc on the test)
3. (probably unrelated) use a different temp dir for each test

## Related Issue



## Motivation and Context


## How Has This Been Tested

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGES.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
