### PR TITLE
Port Compose Desktop ProGuard support to IntelliJPlugin

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/dsl/ProguardSettings.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/dsl/ProguardSettings.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.intellij.dsl
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import javax.inject.Inject
+import org.jetbrains.intellij.utils.nullableProperty
+import org.jetbrains.intellij.utils.notNullProperty
+
+private const val DEFAULT_PROGUARD_VERSION = "7.2.2"
+
+abstract class ProguardSettings @Inject constructor(
+    objects: ObjectFactory,
+) {
+    val version: Property<String> = objects.notNullProperty(DEFAULT_PROGUARD_VERSION)
+    val maxHeapSize: Property<String?> = objects.nullableProperty()
+    val configurationFiles: ConfigurableFileCollection = objects.fileCollection()
+    val isEnabled: Property<Boolean> = objects.notNullProperty(false)
+    val obfuscate: Property<Boolean> = objects.notNullProperty(false)
+}

--- a/src/main/kotlin/org/jetbrains/intellij/tasks/AbstractProguardTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/tasks/AbstractProguardTask.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.intellij.tasks
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.LocalState
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.TaskAction
+import org.jetbrains.intellij.utils.ExternalToolRunner
+import org.jetbrains.intellij.utils.cliArg
+import org.jetbrains.intellij.utils.ioFile
+import org.jetbrains.intellij.utils.jvmToolFile
+import org.jetbrains.intellij.utils.mangledName
+import org.jetbrains.intellij.utils.normalizedPath
+import org.jetbrains.intellij.utils.notNullProperty
+import org.jetbrains.intellij.utils.nullableProperty
+import java.io.File
+import java.io.Writer
+
+// TODO: generalize some options e.g. defaultComposeRulesFile should just be defaultRulesFile
+abstract class AbstractProguardTask : AbstractTask() {
+
+    @get:Optional
+    @get:InputFiles
+    val inputFiles: ConfigurableFileCollection = objects.fileCollection()
+
+    @get:InputFiles
+    val libraryJars: ConfigurableFileCollection = objects.fileCollection()
+
+    @get:InputFile
+    val mainJar: RegularFileProperty = objects.fileProperty()
+
+    @get:Internal
+    internal val mainJarInDestinationDir: Provider<RegularFile> = mainJar.flatMap {
+        destinationDir.file(it.asFile.name)
+    }
+
+    @get:InputFiles
+    val configurationFiles: ConfigurableFileCollection = objects.fileCollection()
+
+    @get:Optional
+    @get:Input
+    val dontobfuscate: Property<Boolean?> = objects.nullableProperty()
+
+    // todo: DSL for excluding default rules
+    // also consider pulling coroutines rules from coroutines artifact
+    // https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro
+    @get:Optional
+    @get:InputFile
+    val defaultComposeRulesFile: RegularFileProperty = objects.fileProperty()
+
+    @get:Input
+    val proguardVersion: Property<String> = objects.notNullProperty()
+
+    @get:Input
+    val javaHome: Property<String> = objects.notNullProperty(System.getProperty("java.home"))
+
+    @get:Optional
+    @get:Input
+    val mainClass: Property<String?> = objects.nullableProperty()
+
+    @get:Internal
+    val maxHeapSize: Property<String?> = objects.nullableProperty()
+
+    @get:OutputDirectory
+    val destinationDir: DirectoryProperty = objects.directoryProperty()
+
+    @get:LocalState
+    protected val workingDir: Provider<Directory> = project.layout.buildDirectory.dir("compose/tmp/$name")
+
+    private val rootConfigurationFile = workingDir.map { it.file("root-config.pro") }
+
+    private val jarsConfigurationFile = workingDir.map { it.file("jars-config.pro") }
+
+    @TaskAction
+    fun execute() {
+        val javaHome = File(javaHome.get())
+        val proguardFiles = project.configurations.detachedConfiguration(
+            project.dependencies.create("com.guardsquare:proguard-gradle:${proguardVersion.get()}")
+        ).files
+
+        cleanDirs(destinationDir, workingDir)
+        val destinationDir = destinationDir.ioFile.absoluteFile
+
+        // todo: can be cached for a jdk
+        val jmods = javaHome.resolve("jmods").walk().filter {
+            it.isFile && it.path.endsWith("jmod", ignoreCase = true)
+        }.toList()
+
+        val inputToOutputJars = LinkedHashMap<File, File>()
+        // avoid mangling mainJar
+        inputToOutputJars[mainJar.ioFile] = mainJarInDestinationDir.ioFile
+        for (inputFile in inputFiles) {
+            if (inputFile.name.endsWith(".jar", ignoreCase = true)) {
+                inputToOutputJars.putIfAbsent(inputFile, destinationDir.resolve(inputFile.mangledName()))
+            } else {
+                inputFile.copyTo(destinationDir.resolve(inputFile.name))
+            }
+        }
+
+        jarsConfigurationFile.ioFile.bufferedWriter().use { writer ->
+            for ((input, output) in inputToOutputJars.entries) {
+                writer.writeLn("-injars '${input.normalizedPath()}'")
+                writer.writeLn("-outjars '${output.normalizedPath()}'")
+            }
+
+            for (jmod in jmods) {
+                writer.writeLn("-libraryjars '${jmod.normalizedPath()}'(!**.jar;!module-info.class)")
+            }
+            for (libraryJar in libraryJars) {
+                writer.writeLn("-libraryjars '${libraryJar.canonicalPath}'")
+            }
+            // TODO: do this here or in the IntelliJPlugin?
+            val sourceSets = project.extensions.findByName("sourceSets") as SourceSetContainer
+            sourceSets.getByName("main").compileClasspath.forEach {
+                writer.writeLn("-libraryjars '${it.canonicalPath}'")
+            }
+        }
+
+        rootConfigurationFile.ioFile.bufferedWriter().use { writer ->
+            if (dontobfuscate.orNull == true) {
+                writer.writeLn("-dontobfuscate")
+            }
+
+            if (mainClass.isPresent) {
+                writer.writeLn("""
+                    -keep public class ${mainClass.get()} {
+                        public static void main(java.lang.String[]);
+                    }
+                """.trimIndent())
+            }
+
+            val includeFiles = sequenceOf(
+                jarsConfigurationFile.ioFile,
+                defaultComposeRulesFile.ioFile
+            ) + configurationFiles.files.asSequence()
+            for (configFile in includeFiles.filterNotNull()) {
+                writer.writeLn("-include '${configFile.normalizedPath()}'")
+            }
+        }
+
+        val javaBinary = jvmToolFile(toolName = "java", javaHome = javaHome)
+        val args = arrayListOf<String>().apply {
+            val maxHeapSize = maxHeapSize.orNull
+            if (maxHeapSize != null) {
+                add("-Xmx:$maxHeapSize")
+            }
+            cliArg("-cp", proguardFiles.map { it.normalizedPath() }.joinToString(File.pathSeparator))
+            add("proguard.ProGuard")
+            // todo: consider separate flag
+            cliArg("-verbose", verbose)
+            cliArg("-include", rootConfigurationFile)
+        }
+
+        runExternalTool(
+            tool = javaBinary,
+            args = args,
+            environment = emptyMap(),
+            logToConsole = ExternalToolRunner.LogToConsole.Always
+        ).assertNormalExitValue()
+    }
+
+    private fun Writer.writeLn(s: String) {
+        write(s)
+        write("\n")
+    }
+}

--- a/src/main/kotlin/org/jetbrains/intellij/tasks/AbstractTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/tasks/AbstractTask.kt
@@ -1,0 +1,50 @@
+package org.jetbrains.intellij.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.Directory
+import org.gradle.api.file.FileSystemLocation
+import org.gradle.api.internal.file.FileOperations
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.LocalState
+import org.gradle.process.ExecOperations
+import org.jetbrains.intellij.utils.ExternalToolRunner
+import javax.inject.Inject
+
+// TODO: AbstractTask from Compose plugin. Keep this or merge into AbstractProguardTask?
+abstract class AbstractTask : DefaultTask() {
+    @get:Inject
+    protected abstract val objects: ObjectFactory
+
+    @get:Inject
+    protected abstract val providers: ProviderFactory
+    @get:Internal
+    val verbose: Property<Boolean> = objects.property(Boolean::class.java).apply {
+        set(providers.provider {
+            logger.isDebugEnabled
+        })
+    }
+
+    @get:Inject
+    protected abstract val execOperations: ExecOperations
+
+    @get:Inject
+    protected abstract val fileOperations: FileOperations
+
+    @get:LocalState
+    protected val logsDir: Provider<Directory> = project.layout.buildDirectory.dir("intellij/logs/$name")
+
+    @get:Internal
+    internal val runExternalTool: ExternalToolRunner
+        get() = ExternalToolRunner(verbose, logsDir, execOperations)
+
+    protected fun cleanDirs(vararg dirs: Provider<out FileSystemLocation>) {
+        for (dir in dirs) {
+            fileOperations.delete(dir)
+            fileOperations.mkdir(dir)
+        }
+    }
+}

--- a/src/main/kotlin/org/jetbrains/intellij/utils/ExternalToolRunner.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/utils/ExternalToolRunner.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.intellij.utils
+
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecResult
+import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+internal class ExternalToolRunner(
+    private val verbose: Property<Boolean>,
+    private val logsDir: Provider<Directory>,
+    private val execOperations: ExecOperations
+) {
+    internal enum class LogToConsole {
+        Always,
+        Never,
+        OnlyWhenVerbose
+    }
+
+    operator fun invoke(
+        tool: File,
+        args: Collection<String>,
+        environment: Map<String, Any> = emptyMap(),
+        workingDir: File? = null,
+        checkExitCodeIsNormal: Boolean = true,
+        processStdout: Function1<String, Unit>? = null,
+        logToConsole: LogToConsole = LogToConsole.OnlyWhenVerbose
+    ): ExecResult {
+        val logsDir = logsDir.ioFile
+        logsDir.mkdirs()
+
+        val toolName = tool.nameWithoutExtension
+        val outFile = logsDir.resolve("${toolName}-${currentTimeStamp()}-out.txt")
+        val errFile = logsDir.resolve("${toolName}-${currentTimeStamp()}-err.txt")
+
+        val result = outFile.outputStream().buffered().use { outFileStream ->
+            errFile.outputStream().buffered().use { errFileStream ->
+                execOperations.exec {
+                    val spec = this
+                    spec.executable = tool.absolutePath
+                    spec.args(*args.toTypedArray())
+                    workingDir?.let { wd -> spec.workingDir(wd) }
+                    spec.environment(environment)
+                    // check exit value later
+                    spec.isIgnoreExitValue = true
+
+                    @Suppress("NAME_SHADOWING")
+                    val logToConsole = when (logToConsole) {
+                        LogToConsole.Always -> true
+                        LogToConsole.Never -> false
+                        LogToConsole.OnlyWhenVerbose -> verbose.get()
+                    }
+                    if (logToConsole) {
+                        spec.standardOutput = spec.standardOutput.alsoOutputTo(outFileStream)
+                        spec.errorOutput = spec.errorOutput.alsoOutputTo(errFileStream)
+                    } else {
+                        spec.standardOutput = outFileStream
+                        spec.errorOutput = errFileStream
+                    }
+                }
+            }
+        }
+
+        if (checkExitCodeIsNormal && result.exitValue != 0) {
+            val errMsg = buildString {
+                appendLine("External tool execution failed:")
+                val cmd = (listOf(tool.absolutePath) + args).joinToString(", ")
+                appendLine("* Command: [$cmd]")
+                appendLine("* Working dir: [${workingDir?.absolutePath.orEmpty()}]")
+                appendLine("* Exit code: ${result.exitValue}")
+                appendLine("* Standard output log: ${outFile.absolutePath}")
+                appendLine("* Error log: ${errFile.absolutePath}")
+            }
+
+            error(errMsg)
+        }
+
+        if (processStdout != null) {
+            processStdout(outFile.readText())
+        }
+
+        if (result.exitValue == 0) {
+            outFile.delete()
+            errFile.delete()
+        }
+
+        return result
+    }
+
+    private fun currentTimeStamp() =
+        LocalDateTime.now()
+            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss"))
+}

--- a/src/main/kotlin/org/jetbrains/intellij/utils/MultiOutputStream.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/utils/MultiOutputStream.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020-2021 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.intellij.utils
+
+import java.io.FilterOutputStream
+import java.io.OutputStream
+
+internal class MultiOutputStream(
+    mainStream: OutputStream,
+    private val secondaryStream: OutputStream
+) : FilterOutputStream(mainStream) {
+    override fun write(b: Int) {
+        super.write(b)
+        secondaryStream.write(b)
+    }
+
+    override fun flush() {
+        super.flush()
+        secondaryStream.flush()
+    }
+
+    override fun close() {
+        try {
+            super.close()
+        } finally {
+            secondaryStream.close()
+        }
+    }
+}
+
+internal fun OutputStream.alsoOutputTo(secondaryStream: OutputStream): OutputStream =
+    MultiOutputStream(this, secondaryStream)

--- a/src/main/kotlin/org/jetbrains/intellij/utils/cliArgUtils.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/utils/cliArgUtils.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.intellij.utils
+
+import org.gradle.api.file.FileSystemLocation
+import org.gradle.api.provider.Provider
+import java.io.File
+
+internal fun <T : Any?> MutableCollection<String>.cliArg(
+    name: String,
+    value: T?,
+    fn: (T) -> String = defaultToString()
+) {
+    if (value is Boolean) {
+        if (value) add(name)
+    } else if (value != null) {
+        add(name)
+        add(fn(value))
+    }
+}
+
+internal fun <T : Any?> MutableCollection<String>.cliArg(
+    name: String,
+    value: Provider<T>,
+    fn: (T) -> String = defaultToString()
+) {
+    cliArg(name, value.orNull, fn)
+}
+
+internal fun MutableCollection<String>.javaOption(value: String) {
+    cliArg("--java-options", "'$value'")
+}
+
+private fun <T : Any?> defaultToString(): (T) -> String =
+    {
+        val asString = when (it) {
+            is FileSystemLocation -> it.asFile.normalizedPath()
+            is File -> it.normalizedPath()
+            else -> it.toString()
+        }
+        "\"$asString\""
+    }

--- a/src/main/kotlin/org/jetbrains/intellij/utils/fileUtils.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/utils/fileUtils.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.intellij.utils
+
+import java.io.*
+import java.security.DigestInputStream
+import java.security.MessageDigest
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+
+internal fun File.mangledName(): String =
+    buildString {
+        append(nameWithoutExtension)
+        append("-")
+        append(contentHash())
+        val ext = extension
+        if (ext.isNotBlank()) {
+            append(".$ext")
+        }
+    }
+
+internal fun File.contentHash(): String {
+    val md5 = MessageDigest.getInstance("MD5")
+    if (isDirectory) {
+        walk()
+            .filter { it.isFile }
+            .sortedBy { it.relativeTo(this).path }
+            .forEach { md5.digestContent(it) }
+    } else {
+        md5.digestContent(this)
+    }
+    val digest = md5.digest()
+    return buildString(digest.size * 2) {
+        for (byte in digest) {
+            append(Integer.toHexString(0xFF and byte.toInt()))
+        }
+    }
+}
+
+private fun MessageDigest.digestContent(file: File) {
+    file.inputStream().buffered().use { fis ->
+        DigestInputStream(fis, this).use { ds ->
+            while (ds.read() != -1) {}
+        }
+    }
+}
+
+internal inline fun transformJar(
+    sourceJar: File,
+    targetJar: File,
+    fn: (entry: ZipEntry, zin: ZipInputStream, zout: ZipOutputStream) -> Unit
+) {
+    ZipInputStream(FileInputStream(sourceJar).buffered()).use { zin ->
+        ZipOutputStream(FileOutputStream(targetJar).buffered()).use { zout ->
+            for (sourceEntry in generateSequence { zin.nextEntry }) {
+                fn(sourceEntry, zin, zout)
+            }
+        }
+    }
+}
+
+internal fun copyZipEntry(
+    entry: ZipEntry,
+    from: InputStream,
+    to: ZipOutputStream,
+) {
+    val newEntry = ZipEntry(entry.name).apply {
+        comment = entry.comment
+        extra = entry.extra
+    }
+    to.withNewEntry(newEntry) {
+        from.copyTo(to)
+    }
+}
+
+internal inline fun ZipOutputStream.withNewEntry(zipEntry: ZipEntry, fn: () -> Unit) {
+    putNextEntry(zipEntry)
+    fn()
+    closeEntry()
+}
+
+internal fun InputStream.copyTo(file: File) {
+    file.outputStream().buffered().use { os ->
+        copyTo(os)
+    }
+}
+
+/*
+@Internal
+internal fun findOutputFileOrDir(dir: File, targetFormat: TargetFormat): File =
+    when (targetFormat) {
+        TargetFormat.AppImage -> dir
+        else -> dir.walk().first { it.isFile && it.name.endsWith(targetFormat.fileExt) }
+    }
+*/
+
+internal fun File.checkExistingFile(): File =
+    apply {
+        check(isFile) { "'$absolutePath' does not exist" }
+    }
+
+internal val File.isJarFile: Boolean
+    get() = name.endsWith(".jar", ignoreCase = true) && isFile
+
+internal fun File.normalizedPath() =
+    if (currentOS == OS.Windows) absolutePath.replace("\\", "\\\\") else absolutePath

--- a/src/main/kotlin/org/jetbrains/intellij/utils/gradleUtils.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/utils/gradleUtils.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.intellij.utils
+
+import org.gradle.api.Task
+import org.gradle.api.file.Directory
+import org.gradle.api.file.FileSystemLocation
+import org.gradle.api.file.RegularFile
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import java.io.File
+
+@SuppressWarnings("UNCHECKED_CAST")
+internal inline fun <reified T : Any> ObjectFactory.nullableProperty(): Property<T?> =
+    property(T::class.java) as Property<T?>
+
+internal inline fun <reified T : Any> ObjectFactory.notNullProperty(): Property<T> =
+    property(T::class.java)
+
+internal inline fun <reified T : Any> ObjectFactory.notNullProperty(defaultValue: T): Property<T> =
+    property(T::class.java).value(defaultValue)
+
+internal inline fun <reified T> Provider<T>.toProperty(objects: ObjectFactory): Property<T> =
+    objects.property(T::class.java).value(this)
+
+internal inline fun <reified T> Task.provider(noinline fn: () -> T): Provider<T> =
+    project.provider(fn)
+
+internal fun Provider<Directory>.file(relativePath: String): Provider<RegularFile> =
+    map { it.file(relativePath) }
+
+internal fun Provider<Directory>.dir(relativePath: String): Provider<Directory> =
+    map { it.dir(relativePath) }
+
+internal inline fun <reified T> ObjectFactory.new(vararg params: Any): T =
+    newInstance(T::class.java, *params)
+
+internal fun <T : Task> TaskProvider<T>.dependsOn(vararg dependencies: Any) {
+    configure { dependsOn(*dependencies) }
+}
+
+internal val <T : FileSystemLocation> Provider<T>.ioFile: File
+    get() = get().asFile
+
+internal val <T : FileSystemLocation> Provider<T>.ioFileOrNull: File?
+    get() = orNull?.asFile

--- a/src/main/kotlin/org/jetbrains/intellij/utils/osUtils.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/utils/osUtils.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.intellij.utils
+
+import org.gradle.api.provider.Provider
+import java.io.File
+
+// From org.jetbrains.compose.desktop.application.tasks.AbstractCheckNativeDistributionRuntime
+internal const val MIN_JAVA_RUNTIME_VERSION = 15
+
+internal enum class OS(val id: String) {
+    Linux("linux"),
+    Windows("windows"),
+    MacOS("macos")
+}
+
+internal enum class Arch(val id: String) {
+    X64("x64"),
+    Arm64("arm64")
+}
+
+internal data class Target(val os: OS, val arch: Arch) {
+    val id: String
+        get() = "${os.id}-${arch.id}"
+}
+
+internal val currentTarget by lazy {
+    Target(currentOS, currentArch)
+}
+
+internal val currentArch by lazy {
+    val osArch = System.getProperty("os.arch")
+    when (osArch) {
+        "x86_64", "amd64" -> Arch.X64
+        "aarch64" -> Arch.Arm64
+        else -> error("Unsupported OS arch: $osArch")
+    }
+}
+
+internal val currentOS: OS by lazy {
+    val os = System.getProperty("os.name")
+    when {
+        os.equals("Mac OS X", ignoreCase = true) -> OS.MacOS
+        os.startsWith("Win", ignoreCase = true) -> OS.Windows
+        os.startsWith("Linux", ignoreCase = true) -> OS.Linux
+        else -> error("Unknown OS name: $os")
+    }
+}
+
+internal fun executableName(nameWithoutExtension: String): String =
+    if (currentOS == OS.Windows) "$nameWithoutExtension.exe" else nameWithoutExtension
+
+internal fun javaExecutable(javaHome: String): String =
+    File(javaHome).resolve("bin/${executableName("java")}").absolutePath
+
+internal object MacUtils {
+    val codesign: File by lazy {
+        File("/usr/bin/codesign").checkExistingFile()
+    }
+
+    val security: File by lazy {
+        File("/usr/bin/security").checkExistingFile()
+    }
+
+    val xcrun: File by lazy {
+        File("/usr/bin/xcrun").checkExistingFile()
+    }
+
+    val xcodeBuild: File by lazy {
+        File("/usr/bin/xcodebuild").checkExistingFile()
+    }
+
+    val make: File by lazy {
+        File("/usr/bin/make").checkExistingFile()
+    }
+
+    val open: File by lazy {
+        File("/usr/bin/open").checkExistingFile()
+    }
+
+}
+
+internal object UnixUtils {
+    val git: File by lazy {
+        File("/usr/bin/git").checkExistingFile()
+    }
+}
+
+internal fun jvmToolFile(toolName: String, javaHome: Provider<String>): File =
+    jvmToolFile(toolName, File(javaHome.get()))
+
+internal fun jvmToolFile(toolName: String, javaHome: File): File {
+    val jtool = javaHome.resolve("bin/${executableName(toolName)}")
+    check(jtool.isFile) {
+        "Invalid JDK: $jtool is not a file! \n" +
+                "Ensure JAVA_HOME or buildSettings.javaHome is set to JDK $MIN_JAVA_RUNTIME_VERSION or newer"
+    }
+    return jtool
+}

--- a/src/main/resources/proguard/default-config.pro
+++ b/src/main/resources/proguard/default-config.pro
@@ -1,0 +1,1 @@
+-keep class ** extends com.intellij.AbstractBundle { *; }


### PR DESCRIPTION
# Pull Request Details

This is a first attempt at porting the ProGuard support from Compose Desktop Gradle Plugin to the IntelliJ Gradle Plugin.

## Description

Recently, ProGuard support was [added to the Compose Desktop Gradle plugin](https://github.com/JetBrains/compose-jb/pull/2313) by adding a Gradle task which configures & executes ProGuard, and a simple DSL configuration.

This PR copies the [AbstractProguardTask](https://github.com/JetBrains/compose-jb/blob/master/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractProguardTask.kt), [ProguardSettings](https://github.com/JetBrains/compose-jb/blob/master/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/ProguardSettings.kt) and related utility code.

Some of the utility code is probably not required and can be removed but currently I copied & pasted complete files.

I've slightly modified the `AbstractProguardTask` to make it work in the IntelliJ Gradle Plugin: mostly for collecting the library jars (which should maybe be done instead in the IntelliJ Plugin?) and making the `mainClass` optional.

I've added a `configureProguardTask` in the `IntelliJPlugin` to configure the plugin and set the input & output files.

A plugin block can be added to an IntelliJ Plugin project:

```
tasks {
     ...
    proguard {
        configurationFiles.from("proguard-rules.pro")
       dontobfuscate.set(false)
    }
}
```

Running the `./gradlew proguard` command currently produces a proguarded jar in `build/lib/proguard/` but this may not be the most appropriate location. The publish task should also be able to publish this version of the jar instead of the original.

A default ProGuard rules file is added to the resources. We should add some default rules to the configuration that make sense for IntelliJ Plugin projects.

We should probably also print the various logging files by default into the `build` folder; especially the `mapping.txt` file when obfuscation is enabled (`-printmapping mapping.txt`).

## Motivation and Context

Provide a simplified integration for ProGuard shrinking, optimization and name obfuscation compared to e.g. [using the current `ProGuardTask`](https://github.com/beansoft/intellij-platform-plugin-template-proguard/blob/main/build.gradle.kts#L47)

## How Has This Been Tested

Currently manually tested on a small sample: please advise on how this should normally be tested.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGES.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
