### PR TITLE
Make `Project.logCategory` appends `project.name` to `project.path` with a delimiter

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/utils.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/utils.kt
@@ -283,7 +283,7 @@ private fun log(level: LogLevel, logCategory: String?, message: String, e: Throw
     }
 }
 
-fun Project.logCategory(): String = path + name.takeIf { ":$it" != path }.orEmpty()
+fun Project.logCategory(): String = path + if (path.subString(1) != name) " $name" else ""
 
 fun Task.logCategory(): String = project.logCategory() + path.removePrefix(project.logCategory())
 

--- a/src/main/kotlin/org/jetbrains/intellij/utils.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/utils.kt
@@ -283,7 +283,7 @@ private fun log(level: LogLevel, logCategory: String?, message: String, e: Throw
     }
 }
 
-fun Project.logCategory(): String = path + if (path.subString(1) != name) " $name" else ""
+fun Project.logCategory(): String = path + if (path.endsWith(name)) " $name" else ""
 
 fun Task.logCategory(): String = project.logCategory() + path.removePrefix(project.logCategory())
 


### PR DESCRIPTION
# Pull Request Details

In a nested multi module project, if the name and the path are not equal, they are appended however they are appended without any separator or delimiter. This change propose to insert a space before the name.

So
[gradle-intellij-plugin :modules:corecore] ...

Becomes
[gradle-intellij-plugin :modules:core core] ...



## Motivation and Context

This not a big fix, but this makes logs easier to read. 

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

I don't think listing this change in the changelog noteworthy.

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGES.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
