### PR TITLE
Make RunIdeBase.pluginsDir a `@Classpath` input, fixes cacheability of buildSearchableOptions

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/tasks/RunIdeBase.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/tasks/RunIdeBase.kt
@@ -94,7 +94,7 @@ abstract class RunIdeBase : JavaExec() {
      * Default value: [PrepareSandboxTask.getDestinationDir]
      */
     @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.NONE)
+    @get:Classpath
     abstract val pluginsDir: DirectoryProperty
 
     /**


### PR DESCRIPTION
Without `@Classpath`, the jar metadata changes create different cache keys resulting in build cache misses. 
See [this build comparison](https://ge.apollographql.com/c/csjnjpd63byeq/tstsfyflm5twe/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure&expanded=WyJweTRuaGlydmc1Ynk2LXBsdWdpbnNkaXIiLCJweTRuaGlydmc1Ynk2LXBsdWdpbnNEaXItMC0wIiwicHk0bmhpcnZnNWJ5Ni1wbHVnaW5zRGlyLTAtMC0wIl0#py4nhirvg5by6-task-class) for an example.

Many thanks to @runningcode for the diagnostic and pointers 🙏 

