### PR TITLE
Hopefully fix build cacheability of `jarSearchableOptions`

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt
@@ -924,7 +924,7 @@ abstract class IntelliJPlugin : Plugin<Project> {
         val prepareSandboxTaskProvider = project.tasks.named<PrepareSandboxTask>(PREPARE_SANDBOX_TASK_NAME)
 
         project.tasks.register<JarSearchableOptionsTask>(JAR_SEARCHABLE_OPTIONS_TASK_NAME) {
-            outputDir.convention(project.layout.buildDirectory.dir(SEARCHABLE_OPTIONS_DIR_NAME))
+            inputDir.convention(project.layout.buildDirectory.dir(SEARCHABLE_OPTIONS_DIR_NAME))
             pluginName.convention(prepareSandboxTaskProvider.flatMap { prepareSandboxTask ->
                 prepareSandboxTask.pluginName
             })
@@ -939,7 +939,7 @@ abstract class IntelliJPlugin : Plugin<Project> {
 
             dependsOn(BUILD_SEARCHABLE_OPTIONS_TASK_NAME)
             dependsOn(PREPARE_SANDBOX_TASK_NAME)
-            onlyIf { outputDir.get().asFile.isDirectory }
+            onlyIf { inputDir.get().asFile.isDirectory }
         }
     }
 

--- a/src/main/kotlin/org/jetbrains/intellij/tasks/JarSearchableOptionsTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/tasks/JarSearchableOptionsTask.kt
@@ -26,9 +26,10 @@ abstract class JarSearchableOptionsTask : Jar() {
      *
      * Default value: `build/searchableOptions`
      */
-    @get:OutputDirectory
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:Optional
-    abstract val outputDir: DirectoryProperty
+    abstract val inputDir: DirectoryProperty
 
     /**
      * The name of the plugin.
@@ -82,7 +83,7 @@ abstract class JarSearchableOptionsTask : Jar() {
                     }
                 }
             }
-            outputDir.get().asPath
+            inputDir.get().asPath
         })
 
         this.eachFile { path = "search/$name" }


### PR DESCRIPTION
_Preamble_: opening this PR as it's adding more context that an issue but I'm not 100% sure about everything that's going on in there. Feel free to close or modify this PR.

The issue is we have some tasks that are not cacheable because over overlapping outputs ([build scan](https://ge.apollographql.com/s/tstsfyflm5twe/timeline?cacheability=cacheable,overlapping-outputs,validation-failure&outcome=success,failed&sort=longest)). My understanding is that `outputDir` is the output of `BuildSearchableOptionsTask` and therefore the input of `JarSearchableOptionsTask`. The output of `JarSearchableOptionsTask` being decided by archiveBaseName ([here](https://github.com/JetBrains/gradle-intellij-plugin/blob/b7da6ab3b1cc309c0bf8fbf9f469277446c6ef1b/src/main/kotlin/org/jetbrains/intellij/IntelliJPlugin.kt#L934)).

Let me know what you think.
