### PR TITLE
Fix toolchain warning during build in Gradle 8.x

### DIFF
--- a/.github/workflows/release-nightly-scheduled.yml
+++ b/.github/workflows/release-nightly-scheduled.yml
@@ -13,3 +13,4 @@ jobs:
   release-nightly:
     if: contains('JetBrains/gradle-intellij-plugin', github.repository)
     uses: ./.github/workflows/release-nightly.yml
+    secrets: inherit

--- a/.github/workflows/reusable-codeInspection.yml
+++ b/.github/workflows/reusable-codeInspection.yml
@@ -14,5 +14,5 @@ jobs:
           fetch-depth: 0 # only report issues that appeared in a PR
 
       - name: Qodana - Code Inspection
-        uses: JetBrains/qodana-action@v2023.1.4
+        uses: JetBrains/qodana-action@v2023.1.5
         if: ${{ false }}  # disable for now

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-version=1.14.1
-snapshotVersion=1.14.2
+version=1.14.2
+snapshotVersion=1.14.3
 snapshot=false
 group=org.jetbrains.intellij.plugins
 artifactId=gradle-intellij-plugin

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,7 @@ pluginManagement {
 
 plugins {
     id("com.gradle.enterprise") version("3.12.6")
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.5.0")
 }
 
 rootProject.name = "gradle-intellij-plugin"


### PR DESCRIPTION

# Pull Request Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes

> Using a toolchain installed via auto-provisioning, but having no toolchain repositories configured. This behavior is deprecated. Consider defining toolchain download repositories, otherwise the build might fail in clean environments; see https://docs.gradle.org/8.1.1/userguide/toolchains.html#sub:download_repositories


## Related Issue

None, but the issue is internal and trivial, does not affect users, happy to open if needed.

## Motivation and Context

Cleaner build during contribution, so it's clear that the build works as expected.

## How Has This Been Tested

`gradlew build -x test`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGELOG.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
