### PR TITLE
Fix #1413: Replace deprecated JavaPluginConventions usage

### DIFF
--- a/.github/workflows/release-nightly-scheduled.yml
+++ b/.github/workflows/release-nightly-scheduled.yml
@@ -13,3 +13,4 @@ jobs:
   release-nightly:
     if: contains('JetBrains/gradle-intellij-plugin', github.repository)
     uses: ./.github/workflows/release-nightly.yml
+    secrets: inherit

--- a/.github/workflows/reusable-codeInspection.yml
+++ b/.github/workflows/reusable-codeInspection.yml
@@ -14,5 +14,5 @@ jobs:
           fetch-depth: 0 # only report issues that appeared in a PR
 
       - name: Qodana - Code Inspection
-        uses: JetBrains/qodana-action@v2023.1.4
+        uses: JetBrains/qodana-action@v2023.1.5
         if: ${{ false }}  # disable for now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Improved checking if `Provider` holds non-empty value
 - Fixed calculationg of JVM arguments for running tests [#1360](../../issues/1360)
 - Introduce CommandLineArgumentProviders for better management of JVM arguments and avoiding passing absolute paths to support Gradle Build Cache [#1376](../../issues/1376)
+- Replace deprecated `JavaPluginConvention` usages with `JavaPluginExtension` for Gradle 8.2 and 9.x compatibility [#1413](../../issues/1413)
 
 ### Removed
 - Removed redundant `SetupInstrumentCodeTask` task

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-version=1.14.1
-snapshotVersion=1.14.2
+version=1.14.2
+snapshotVersion=1.14.3
 snapshot=false
 group=org.jetbrains.intellij.plugins
 artifactId=gradle-intellij-plugin

--- a/src/main/kotlin/org/jetbrains/intellij/utils.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/utils.kt
@@ -1,7 +1,7 @@
 // Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
 
 @file:JvmName("Utils")
-@file:Suppress("DEPRECATION", "BooleanMethodIsAlwaysInverted")
+@file:Suppress("BooleanMethodIsAlwaysInverted")
 
 package org.jetbrains.intellij
 
@@ -22,12 +22,12 @@ import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.file.RegularFile
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logging
-import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.plugins.PluginInstantiationException
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.SourceSet
 import org.gradle.internal.os.OperatingSystem
-import org.gradle.kotlin.dsl.getPlugin
+import org.gradle.kotlin.dsl.getByName
 import org.gradle.util.GradleVersion
 import org.jdom2.Document
 import org.jdom2.output.Format
@@ -61,7 +61,7 @@ import java.util.jar.Manifest
 val MAJOR_VERSION_PATTERN = "(RIDER-|GO-)?\\d{4}\\.\\d-(EAP\\d*-)?SNAPSHOT".toPattern()
 
 internal fun sourcePluginXmlFiles(project: Project) = project
-    .convention.getPlugin<JavaPluginConvention>()
+    .extensions.getByName<JavaPluginExtension>("java") // Name hard-coded in JavaBasePlugin.addExtensions and well-known.
     .sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME) // TODO: iterate over all sourceSets?
     .resources
     .srcDirs


### PR DESCRIPTION
# Pull Request Details

## Description

Replaces `.convention` usage with `.extension` and `JavaPluginConvention` with `JavaPluginExtension`.
`JavaPluginExtension` was added in Gradle 4.10. Consdering the docs say:
> This project requires Gradle 7.3 or newer. -- [docs](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#usage)

this change should bear very low risk.

## Related Issue

Fixes #1413

## Motivation and Context

Gradle is removing long-deprecated conventions APIs in favor of extensions. In Gradle 8.2 (now in RC2) they added nagging so plugin users will be nagged but they can't action the nagging until there's a version of the plugin released which doesn't use conventions.

## How Has This Been Tested

`gradlew build`
and
`gradlew :publishSnapshotPublicationToMavenLocal` + `mavenLocal()` repo, because `includeBuild` approach doesn't work as described in CONTRIBUTING.md.


## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [ ] I have updated the documentation accordingly.
- [x] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGELOG.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
