### PR TITLE
Remove redundant Gradle version from CI

### DIFF
--- a/.github/workflows/reusable-integrationTests.yml
+++ b/.github/workflows/reusable-integrationTests.yml
@@ -18,7 +18,6 @@ jobs:
         gradleVersion:
           - "7.6"
           - "8.2"
-          - "8.2-rc-3"
         os:
           - windows-latest
           - ubuntu-latest

--- a/.github/workflows/reusable-unitTests.yml
+++ b/.github/workflows/reusable-unitTests.yml
@@ -31,7 +31,6 @@ jobs:
         gradleVersion:
           - "7.6"
           - "8.2"
-          - "8.2-rc-3"
         os:
           - windows-latest
           - ubuntu-latest

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -44,7 +44,7 @@ project {
     }
 
     val operatingSystems = listOf("Linux", "Windows", "macOS")
-    val gradleVersions = listOf("7.6", "8.2", "8.2-rc-3")
+    val gradleVersions = listOf("7.6", "8.2")
 
     val buildChain = sequential {
         operatingSystems.forEach { os ->


### PR DESCRIPTION
# Pull Request Details

Gradle 8.2-rc-3 and Gradle 8.2 are nearly equivalent, they were released very close apart.

## How Has This Been Tested

Manual review by @hsz and GHA CI.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGELOG.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
