### PR TITLE
Disable caching for BuildPluginTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 - Renamed `ListProductsReleasesTask.productsReleasesUpdateFiles` property to `ListProductsReleasesTask.ideaProductReleasesUpdateFiles`
+- Disabled caching for `BuildPluginTask`
 
 ### Removed
 - Removed `ListProductsReleasesTask.updatePaths` property

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [next]
 
+### Changed
+- Disabled caching for `BuildPluginTask`
+
 ## [1.15.0] - 2023-07-07
 
 ### Added
@@ -12,7 +15,6 @@
 
 ### Changed
 - Renamed `ListProductsReleasesTask.productsReleasesUpdateFiles` property to `ListProductsReleasesTask.ideaProductReleasesUpdateFiles`
-- Disabled caching for `BuildPluginTask`
 
 ### Removed
 - Removed `ListProductsReleasesTask.updatePaths` property

--- a/src/main/kotlin/org/jetbrains/intellij/tasks/BuildPluginTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/tasks/BuildPluginTask.kt
@@ -2,8 +2,8 @@
 
 package org.jetbrains.intellij.tasks
 
-import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.bundling.Zip
+import org.gradle.work.DisableCachingByDefault
 import org.jetbrains.intellij.IntelliJPluginConstants
 
 /**

--- a/src/main/kotlin/org/jetbrains/intellij/tasks/BuildPluginTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/tasks/BuildPluginTask.kt
@@ -11,7 +11,6 @@ import org.jetbrains.intellij.IntelliJPluginConstants
  *
  * @see [Zip]
  */
-@CacheableTask
 abstract class BuildPluginTask : Zip() {
 
     init {

--- a/src/main/kotlin/org/jetbrains/intellij/tasks/BuildPluginTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/tasks/BuildPluginTask.kt
@@ -11,6 +11,7 @@ import org.jetbrains.intellij.IntelliJPluginConstants
  *
  * @see [Zip]
  */
+ @DisableCachingByDefault(because = "Zip based tasks do not benefit from caching")
 abstract class BuildPluginTask : Zip() {
 
     init {


### PR DESCRIPTION
# Pull Request Details

Disable caching for `BuildPluginTask`

## Description

Disable caching for `BuildPluginTask` because it is a `Zip` task. I/O bound tasks, like `Zip`, can have a negative effect on performance when cached. For this reason, [zip tasks have caching disabled by default](https://github.com/gradle/gradle/blob/master/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/Zip.java#L38).

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves #1426

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Being an I/O bound task, caching `BuildPluginTask` can have a negative effect on performance.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* [clean test](https://ge.jetbrains.com/s/ekdimh5vo6v46)
* [clean integrationTest](https://ge.jetbrains.com/s/debcoo4ijeiw2)
* Published `gradle-intellij-plugin` with changes applied to maven local. Importing the plugin in another project, ran `buildPlugin`, and [verified `buildPlugin` had caching disabled](https://scans.gradle.com/s/3qjpb4i42phle)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [ ] I have updated the documentation accordingly.
- [x] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGELOG.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
