### PR TITLE
Support free arguments passed directly to Plugin Verifier

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
@@ -113,6 +113,15 @@ abstract class RunPluginVerifierTask @Inject constructor(
     abstract val verifierPath: Property<String>
 
     /**
+     * Free arguments passed to the IntelliJ Plugin Verifier exactly as specified.
+     *
+     * They can be used in addition to the arguments that are provided by DSL options.
+     */
+    @get:Input
+    @get:Optional
+    abstract val freeArgs: ListProperty<String>
+
+    /**
      * JAR or ZIP file of the plugin to verify.
      * If empty, the task will be skipped.
      *
@@ -467,6 +476,11 @@ abstract class RunPluginVerifierTask @Inject constructor(
         }
         if (offline.get()) {
             args.add("-offline")
+        }
+
+        if (freeArgs.orNull != null) {
+            val freeArgs = freeArgs.get()
+            args.addAll(freeArgs)
         }
 
         return args

--- a/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
@@ -115,7 +115,7 @@ abstract class RunPluginVerifierTask @Inject constructor(
     /**
      * Free arguments passed to the IntelliJ Plugin Verifier exactly as specified.
      *
-     * They can be used in addition to the arguments that are provided by DSL options.
+     * They can be used in addition to the arguments that are provided by dedicated options.
      */
     @get:Input
     @get:Optional


### PR DESCRIPTION
# Pull Request Details

Support arbitrary CLI argument passing to the IntelliJ Plugin Verifier invocations.

## Description

Add DSL support for arbitrary CLI arguments that are passed to the IntelliJ Plugin Verifier _as is_ in addition to the arguments provided by the DSL.

In addition, add a new DSL property `freeArgs` that will hold abritrary number of raw arguments. Such arguments will be passed directly to the Plugin Verifier invocations.

```
freeArgs = [ "-suppress-internal-api-usages", "jetbrains-plugins" ]
```

## Motivation and Context

Currently, arguments passed to the IntelliJ Plugin Verifier must be supported by the DSL in the `runPluginVerifier` task. However, the Plugin Verifier might support additional arguments that are not handled by the DSL. In addition, users might use distinct versions of the Plugin Verifier with varying support for the particular DSL options.

## How Has This Been Tested

Unit tests have been added to cover the invocations.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGELOG.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
