### PR TITLE
Remove patch number from Kotlin version comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Support for Kotlin Coroutines debugging
 - Detect and warn if project adds an explicit dependency on Kotlin Coroutines library
 
+### Fixed
+- Misleading message about Kotlin API version [#1463](../../issues/1463)
+
 ### Changed
 - Disabled caching for `BuildPluginTask`
 

--- a/src/main/kotlin/org/jetbrains/intellij/tasks/VerifyPluginConfigurationTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/tasks/VerifyPluginConfigurationTask.kt
@@ -152,7 +152,7 @@ abstract class VerifyPluginConfigurationTask @Inject constructor(
         val kotlinApiVersion = kotlinApiVersion.orNull?.let(Version::parse)
         val kotlinLanguageVersion = kotlinLanguageVersion.orNull?.let(Version::parse)
         val kotlinVersion = kotlinVersion.orNull?.let(Version::parse)
-        val platformKotlinLanguageVersion = platformBuildVersion.let(::getPlatformKotlinVersion)?.run { Version(major, minor) }
+        val platformKotlinLanguageVersion = platformBuildVersion.let(::getPlatformKotlinVersion)?.run { Version.parse("$major.$minor") }
         val pluginVerifierDownloadPath = pluginVerifierDownloadDir.get().let(Path::of).toAbsolutePath()
         val oldPluginVerifierDownloadPath = providers.systemProperty("user.home").map { "$it/.pluginVerifier/ides" }.get().let(Path::of).toAbsolutePath()
 
@@ -162,7 +162,7 @@ abstract class VerifyPluginConfigurationTask @Inject constructor(
                 .forEach { plugin ->
                     val sinceBuild = plugin.ideaVersion.sinceBuild.let(Version::parse)
                     val sinceBuildJavaVersion = sinceBuild.let(::getPlatformJavaVersion)
-                    val sinceBuildKotlinApiVersion = sinceBuild.let(::getPlatformKotlinVersion)
+                    val sinceBuildKotlinApiVersion = sinceBuild.let(::getPlatformKotlinVersion)?.run { Version.parse("$major.$minor") }
 
                     if (sinceBuild.major < platformBuildVersion.major) {
                         yield("The 'since-build' property is lower than the target IntelliJ Platform major version: $sinceBuild < ${platformBuildVersion.major}.")

--- a/src/test/kotlin/org/jetbrains/intellij/VersionTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/VersionTest.kt
@@ -31,7 +31,6 @@ class VersionTest {
         assertTrue(Version.parse("2021.1.2") > Version.parse("2021.1"))
         assertTrue(Version.parse("2021.1.2") > Version.parse("2021"))
         assertTrue(Version.parse("2021.1.2") > Version.parse("2020"))
-        assertTrue(Version.parse("2021.1.2") > Version.parse("2020"))
         assertEquals(Version.parse("2021.1.0-snapshot"), Version.parse("2021.1.0-SNAPSHOT"))
         assertTrue(Version.parse("2021.1.2-SNAPSHOT.2") > Version.parse("2021.1.2-SNAPSHOT.1"))
         assertTrue(Version.parse("2021.1.2") > Version.parse("2021.1.2-SNAPSHOT.1"))


### PR DESCRIPTION
# Pull Request Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes the patch number from checks on `apiVersion` for `KotlinCompile` tasks.

(And removes a duplicate test.)

## Related Issue

cf. #1463

## Motivation and Context

Since `apiVersion` and `languageVersion` in `compileKotlin.kotlinOptions` can only contain a major and minor version number, the patch number can be ignored completely in this version check.

## How Has This Been Tested

I added two tests that verify that the behaviour in #1156 and #1463 does not occur.

I tried, but was unable to get the tests running on my machine. Sorry for the inconvenience :/

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [ ] I have updated the documentation accordingly.
- [x] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGELOG.md).
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
