### PR TITLE
Align Fleet platform type with Fleet Backend product code for consistency

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/IntelliJPluginConstants.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/IntelliJPluginConstants.kt
@@ -129,7 +129,7 @@ object IntelliJPluginConstants {
     const val PLATFORM_TYPE_PYCHARM = "PY"
     const val PLATFORM_TYPE_PYCHARM_COMMUNITY = "PC"
     const val PLATFORM_TYPE_RIDER = "RD"
-    const val PLATFORM_TYPE_FLEET = "FL"
+    const val PLATFORM_TYPE_FLEET = "FLIJ"
 
     val PLATFORM_TYPES = listOf(
         PLATFORM_TYPE_ANDROID_STUDIO,


### PR DESCRIPTION
# Pull Request Details

It aligns the Fleet Backend platform type string to Fleet Backend product code `FLIJ`.

## Description

Fleet Backend was incorrectly using `FL` as a product code in its configuration, and this has been fixed so the Gradle plugin must be aligned.

**Note that this is written as a breaking change, but Fleet Backend plugin is unreleased so I don't think it requires a major version bump.**

## Related Issue

[FL-21994](https://youtrack.jetbrains.com/issue/FL-21994)

## Motivation and Context

See [FL-21994](https://youtrack.jetbrains.com/issue/FL-21994).

## How Has This Been Tested

Tested manually in https://github.com/vladsoroka/gradle-daemons-services with a `includeBuild` statement.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGELOG.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
