### PR TITLE
Adjust tests for modified output of reports directory by Plugin Verifier

### DIFF
--- a/src/test/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTaskSpec.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTaskSpec.kt
@@ -138,7 +138,7 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
 
         build(RUN_PLUGIN_VERIFIER_TASK_NAME).let {
             val directory = file("build/foo").canonicalPath
-            assertContains("Verification reports directory: $directory", it.output)
+            assertContains("Verification reports for MyName:1.0.0 saved to $directory", it.output)
         }
     }
 
@@ -163,7 +163,7 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         build(RUN_PLUGIN_VERIFIER_TASK_NAME).let { buildResult ->
             val reportsDirectory = file("build/foo")
             val directory = reportsDirectory.canonicalPath
-            assertContains("Verification reports directory: $directory", buildResult.output)
+            assertContains("Verification reports for MyName:1.0.0 saved to $directory", buildResult.output)
             val ideDirs = reportsDirectory.listFiles()
             if (ideDirs.isEmpty()) {
                 Assert.fail("Verification reports directory not found")
@@ -193,7 +193,7 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         build(RUN_PLUGIN_VERIFIER_TASK_NAME).let { buildResult ->
             val reportsDirectory = file("build/foo")
             val directory = reportsDirectory.canonicalPath
-            assertContains("Verification reports directory: $directory", buildResult.output)
+            assertContains("Verification reports for MyName:1.0.0 saved to $directory", buildResult.output)
             val ideDirs = reportsDirectory.listFiles()
             if (ideDirs.isEmpty()) {
                 Assert.fail("Verification reports directory not found")
@@ -222,7 +222,7 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         build(RUN_PLUGIN_VERIFIER_TASK_NAME).let { buildResult ->
             val reportsDirectory = file("build/foo")
             val directory = reportsDirectory.canonicalPath
-            assertContains("Verification reports directory: $directory", buildResult.output)
+            assertContains("Verification reports for MyName:1.0.0 saved to $directory", buildResult.output)
             val ideDirs = reportsDirectory.listFiles()
             if (ideDirs.isEmpty()) {
                 Assert.fail("Verification reports directory not found")
@@ -479,7 +479,7 @@ class RunPluginVerifierTaskSpec : IntelliJPluginSpecBase() {
         build(RUN_PLUGIN_VERIFIER_TASK_NAME).let { buildResult ->
             val reportsDirectory = file("build/foo")
             val directory = reportsDirectory.canonicalPath
-            assertContains("Verification reports directory: $directory", buildResult.output)
+            assertContains("Verification reports for MyName:1.0.0 saved to $directory", buildResult.output)
             val ideDirs = reportsDirectory.listFiles() ?: emptyArray()
             if (ideDirs.isEmpty()) {
                 Assert.fail("Verification reports directory not found")


### PR DESCRIPTION
# Pull Request Details

IntelliJ Plugin Verifier has a modified form of CLI output for output directories. We need to adapt the unit tests.

## Description

A different console message is parsed in the unit tests to capture the verification report directory.

## Motivation and Context

The unit tests have been broken with the release of Plugin Verifier 1.305 and need to be fixed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html).
- [ ] I have updated the documentation accordingly.
- [ ] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CHANGELOG.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
