### PR TITLE
resolve jbr 21 to jcef jbr Closes #278

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/jbr/JbrResolver.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/jbr/JbrResolver.kt
@@ -259,6 +259,7 @@ abstract class JbrResolver @Inject constructor(
                 val buildNumber = Version.parse(buildNumberString)
                 val isJava8 = majorVersion.startsWith("8")
                 val isJava17 = majorVersion.startsWith("17")
+                val isJava21 = majorVersion.startsWith("21")
 
                 val oldFormat = prefix == "jbrex" || isJava8 && buildNumber < Version.parse("1483.24")
                 if (oldFormat) {
@@ -271,7 +272,7 @@ abstract class JbrResolver @Inject constructor(
                 val arch = jbrArch ?: arch(isJava8)
                 if (prefix.isEmpty()) {
                     prefix = when {
-                        isJava17 -> "jbr_jcef-"
+                        isJava17 || isJava21 -> "jbr_jcef-"
                         isJava8 -> "jbrx-"
                         operatingSystem.isMacOsX && arch == "aarch64" -> "jbr_jcef-"
                         buildNumber < Version.parse("1319.6") -> "jbr-"

--- a/src/test/kotlin/org/jetbrains/intellij/jbr/JbrResolverTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/jbr/JbrResolverTest.kt
@@ -18,6 +18,15 @@ class JbrResolverTest : IntelliJPluginSpecBase() {
     fun `resolve 11_0_11b1536_2`() = testJbrResolving("11_0_11b1536.2", "jbr_jcef-11_0_11-$platform-$arch-b1536.2")
 
     @Test
+    fun `resolve 17_0_10b1087_17`() = testJbrResolving("17.0.10b1087.17", "jbr_jcef-17.0.10-$platform-$arch-b1087.17")
+
+    @Test
+    fun `resolve 21_0_2b346_3`() = testJbrResolving("21.0.2b346.3", "jbr_jcef-21.0.2-$platform-$arch-b346.3")
+
+    @Test
+    fun `resolve 21_0_2b341_4`() = testJbrResolving("21.0.2b341.4", "jbr_jcef-21.0.2-$platform-$arch-b341.4")
+
+    @Test
     fun `resolve jbrsdk-11_0_13b1751_16`() = testJbrResolving("jbrsdk-11_0_13b1751.16", "jbrsdk-11_0_13-$platform-$arch-b1751.16")
 
     @Test


### PR DESCRIPTION
JbrResolver resolved jbr 21 to vanilla jbr.

added support for jbr 21 in 
org.jetbrains.intellij.jbr.JbrResolver.JbrArtifact.Companion#from

## Related Issue
https://github.com/JetBrains/gradle-intellij-plugin/issues/1534

## Motivation and Context
when developing plugins with intellij 2024.1 EAP the IDE is downloaded with non jcef jbr and jcef is not supported.

## How Has This Been Tested
added 3 test methods to JbrResolverTest:

```
    @Test
    fun `resolve 17_0_10b1087_17`() = testJbrResolving("17.0.10b1087.17", "jbr_jcef-17.0.10-$platform-$arch-b1087.17")

    @Test
    fun `resolve 21_0_2b346_3`() = testJbrResolving("21.0.2b346.3", "jbr_jcef-21.0.2-$platform-$arch-b346.3")

    @Test
    fun `resolve 21_0_2b341_4`() = testJbrResolving("21.0.2b341.4", "jbr_jcef-21.0.2-$platform-$arch-b341.4")
```
test with:

`./gradlew test --tests "org.jetbrains.intellij.jbr.JbrResolverTest"`

## Checklist

- [x ] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/gradle-intellij-plugin/blob/master/CONTRIBUTING.md) document.
- [ x] My code follows the code style of this project.
- [x ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
