### PR TITLE
Fix `Path.deepResolve` to correctly resolve `singleOrNull` entries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Replace exception with a warning for unknown input paths in `CollectorTransformer`.
 
+### Fixed
+
+- Fix `Path.deepResolve` to correctly resolve `singleOrNull` entries.
+
 ## [2.10.4] - 2025-11-02
 
 ### Added

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/utils/utils.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/utils/utils.kt
@@ -92,7 +92,7 @@ fun FileCollection.platformPath(requestedPlatform: RequestedIntelliJPlatform? = 
 private fun Path.deepResolve(block: Path.() -> Path?) = generateSequence(this) { parent ->
     val entry = parent
         .listDirectoryEntries()
-        .singleOrNull() // pick an entry if it is a singleton in a directory
+        .singleOrNull{ !it.isHidden() } // pick an entry if it is a singleton in a directory, exclude hidden entries
         ?.takeIf { it.isDirectory() } // and this entry is a directory
         ?: return@generateSequence null
     block(entry)


### PR DESCRIPTION
# Pull Request Details

when target directory containing hidden directories or files such as ".DS_Store" are present, IPGP extracting dmg on macOS fails to correctly resolve platform directories.



<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2052 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html).
- [ ] I have updated the documentation accordingly.
- [x] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CHANGELOG.md).
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
