### PR TITLE
Tiered name-conflict handling in PrepareSandboxTask (pre-detect, hash when needed, rename only for real conflicts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Make `parseIdeNotation` and `parsePluginNotation` extension functions public
 
 ### Fixed
 
+- Fix `PrepareSandboxTask` to detect and resolve jar name conflicts at execution time, avoiding configuration-phase resolution of `intellijPlatformRuntimeClasspath` and fixing configuration-cache compatibility. Same-name jars with identical content are no longer treated as conflicts.
 - Fix the execution of `JavaExec` based tasks when the class path gets shortened.
 - Include `IU` and `PY` releases when resolving Plugin Verifier compatible IDEs while requesting `IC` or `PC` for versions `2025.3` (`253`) and later.
 - Fix `ProductReleasesValueSource` to correctly handle and preserve 4-component version numbers (e.g., `2025.3.1.1`) when resolving IDE releases.


### PR DESCRIPTION
# Pull Request Details

**Tiered name-conflict handling in PrepareSandboxTask (pre-detect, hash when needed, rename only for real conflicts)**

## Description

Adds a tiered approach to jar name conflicts in `PrepareSandboxTask`:

1. **Pre-detect** — `detectNameConflicts()` builds a map of filename → list of `File` from `runtimeClasspath`, `pluginJar`, and `pluginsClasspath` and returns only entries with more than one file. No extra file I/O.
2. **Resolve** — `resolveNameConflicts()` runs only when there are exactly two files with the same name: if their MD5 hashes match, it logs "Skipping duplicate content" and does not treat them as a conflict; otherwise it logs "Name conflict detected" with paths.
3. **Rename** — `nameCollisionHelper` uses `nameConflicts` and runs the existing `core` / `core_1` / `core_2` renaming loop only when `conflictFiles != null && conflictFiles.size > 1`.

New helpers: `detectNameConflicts()`, `resolveNameConflicts()`, and `quickFileHash()`. A `nameConflicts` field is set at the start of `copy()` and read by `nameCollisionHelper`. Conflict detection and resolution run at **execution time** (in `copy()` before `super.copy()`), not during task configuration, to avoid resolving `runtimeClasspath` / `pluginsClasspath` too early and triggering "Cannot mutate the state of configuration ':api' after the configuration's child configuration ':intellijPlatformRuntimeClasspath' was resolved."

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

- **Performance** — Hashing is done only for two-file conflicts; renaming is applied only when there is a real conflict.
- **Correctness** — Same-name jars with identical content are no longer treated as conflicts that need renaming.
- **Configuration safety** — Moving detection/resolution to execution time avoids mutating Gradle configurations during the configuration phase and fixes the `:intellijPlatformRuntimeClasspath` / `:api` resolution error in projects using the configuration cache.

## How Has This Been Tested

- **`rename jars with same names`** — Confirms three `core.jar` files still produce `core.jar`, `core_1.jar`, and `core_2.jar`.
- **`PrepareSandboxTaskTest`** — Full class run: all tests pass.
- **Environment** — Gradle 9.3.0, Kotlin (embedded), macOS. Run with:
  - `./gradlew test --tests "org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTaskTest.rename jars with same names"`
  - `./gradlew test --tests "org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTaskTest"`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html).
- [ ] I have updated the documentation accordingly.
- [x] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CHANGELOG.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
