### PR TITLE
clion: add test framework type for CLion

### DIFF
--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/TestFrameworkType.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/TestFrameworkType.kt
@@ -29,6 +29,7 @@ sealed class TestFrameworkType(vararg val coordinates: Coordinates) {
     )
 
     object Plugin {
+        object CLion : TestFrameworkType(Coordinates("com.jetbrains.intellij.clion", "clion-merged-test-framework"))
         object CSS : TestFrameworkType(Coordinates("com.jetbrains.intellij.css", "css-test-framework"))
         object Debugger : TestFrameworkType(Coordinates("com.jetbrains.intellij.platform", "debugger-test-framework"))
         object ExternalSystem : TestFrameworkType(Coordinates("com.jetbrains.intellij.platform", "external-system-test-framework"))


### PR DESCRIPTION
Starting from 2026.1 CLion installed does not come together with testFramework.jar, so it's published to maven
