### PR TITLE
Update module descriptor parsing to support upcoming changes in module-descriptors.jar (IJPL-234640)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Apply Gradle Changelog Plugin conventions automatically when `org.jetbrains.changelog` is present, including default changelog extension values, `changeNotes`, and `publishPlugin` wiring.
+- Supported upcoming changes in module-descriptors.jar format in 262.* IDEs.
 
 ## [2.14.0] - 2026-04-09
 

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/artifacts/transform/CollectorTransformer.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/artifacts/transform/CollectorTransformer.kt
@@ -219,7 +219,7 @@ internal fun loadModuleDescriptors(moduleDescriptorsFile: Path) =
             jarFile
                 .entries()
                 .asSequence()
-                .filter { it.name.endsWith(".xml") }
+                .filter { it.name.endsWith(".xml") && !it.name.contains('/') }
                 .map { jarFile.getInputStream(it) }
                 .mapNotNull { decode<ModuleDescriptor>(it) }
                 .associateBy { it.name }

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/utils/ModuleDescriptorsParser.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/utils/ModuleDescriptorsParser.kt
@@ -29,7 +29,7 @@ internal object ModuleDescriptorsParser {
                     val entries = jarFile.entries()
                     while (entries.hasMoreElements()) {
                         val entry = entries.nextElement()
-                        if (!entry.name.endsWith(".xml")) {
+                        if (!entry.name.endsWith(".xml") || entry.name.contains('/')) {
                             continue
                         }
 

--- a/src/test/kotlin/org/jetbrains/intellij/platform/gradle/providers/ModuleDescriptorCoordinatesTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/platform/gradle/providers/ModuleDescriptorCoordinatesTest.kt
@@ -109,6 +109,13 @@ class ModuleDescriptorCoordinatesTest {
                       </resources>
                     </module>
                 """.trimIndent(),
+                "plugins/intellij.devkit.xml" to """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <plugin id="DevKit">
+                      <plugin-descriptor-module name="intellij.devkit" namespace="${'$'}legacy_jps_module"/>
+                      <module name="intellij.devkit.core" namespace="jetbrains" loading="optional"/>
+                    </plugin>
+                """.trimIndent()
             )
 
             val coordinates = loadModuleDescriptorCoordinates(moduleDescriptorsPath)


### PR DESCRIPTION
# Pull Request Details

Update module descriptor parsing to support upcoming changes in module-descriptors.jar (IJPL-234640)

## Description

Headers of bundled plugins will be stored in plugins/ subdirectory in module-descriptors.jar in next 262.* builds, so to avoid errors, the code now parses only top-level items in the JAR.

## Related Issue

https://youtrack.jetbrains.com/issue/IJPL-234640

## How Has This Been Tested

A test in ModuleDescriptorCoordinatesTest has been added. Also, I checked that the snapshot version of the plugin loads module-descriptor.jar without errors for a snapshot build of IntelliJ IDEA which I built locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [**CONTRIBUTING**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the [documentation](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html).
- [ ] I have updated the documentation accordingly.
- [x] I have included my change in the [**CHANGELOG**](https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/master/CHANGELOG.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
