### PR TITLE
Observe IDE logs out of the box

### DIFF
--- a/api/IntelliJPlatformGradlePlugin.api
+++ b/api/IntelliJPlatformGradlePlugin.api
@@ -3256,11 +3256,13 @@ public abstract class org/jetbrains/intellij/platform/gradle/tasks/RunIdeTask : 
 	public abstract fun getExecutionMode ()Lorg/gradle/api/provider/Property;
 	public fun getPlatformPath ()Ljava/nio/file/Path;
 	public fun getProductInfo ()Lorg/jetbrains/intellij/platform/gradle/models/ProductInfo;
+	public abstract fun getPurgeOldLogDirectories ()Lorg/gradle/api/provider/Property;
 	public abstract fun getSplitModeFrontendBootstrapClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getSplitModeFrontendJoinLink ()Lorg/gradle/api/provider/Property;
 	public fun getSplitModeFrontendJoinLinkFile ()Lorg/gradle/api/provider/Provider;
 	public fun getSplitModeFrontendProperties ()Lorg/gradle/api/provider/Provider;
 	public abstract fun getSplitModeServerPort ()Lorg/gradle/api/provider/Property;
+	public final fun setPurgeOldLogDirectoriesOption (Z)V
 	public fun validateIntelliJPlatformVersion ()V
 	public fun validateSplitModeSupport ()V
 }

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/GenerateSplitModeRunConfigurationsTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/GenerateSplitModeRunConfigurationsTask.kt
@@ -61,10 +61,19 @@ abstract class GenerateSplitModeRunConfigurationsTask : DefaultTask() {
         }
     }
 
+    private fun additionalLogsTab(configurationName: String): String {
+        return when (configurationName) {
+            FRONTEND_CONFIGURATION_NAME -> "<log_file alias=\"Frontend IDE logs\" path=\"\$PROJECT_DIR\$/.intellijPlatform/sandbox/*/*/log_runIdeFrontend/frontend/*/idea.log\" show_all=\"true\" skipped=\"false\" />"
+            BACKEND_CONFIGURATION_NAME -> "<log_file alias=\"Backend IDE logs\" path=\"\$PROJECT_DIR\$/.intellijPlatform/sandbox/*/*/log_runIdeBackend/idea.log\" show_all=\"true\" skipped=\"false\" />"
+            else -> ""
+        }
+    }
+
     private fun gradleRunConfigurationXml(configurationName: String, taskPath: String) = //language=XML
         """
         <component name="ProjectRunConfigurationManager">
           <configuration default="false" name="$configurationName" type="GradleRunConfiguration" factoryName="Gradle">
+            ${additionalLogsTab(configurationName)}
             <ExternalSystemSettings>
               <option name="executionName" />
               <option name="externalProjectPath" value="$PROJECT_DIR_MACRO" />

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/GenerateSplitModeRunConfigurationsTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/GenerateSplitModeRunConfigurationsTask.kt
@@ -78,7 +78,7 @@ abstract class GenerateSplitModeRunConfigurationsTask : DefaultTask() {
               <option name="executionName" />
               <option name="externalProjectPath" value="$PROJECT_DIR_MACRO" />
               <option name="externalSystemIdString" value="GRADLE" />
-              <option name="scriptParameters" value="" />
+              <option name="scriptParameters" value="--$PURGE_OLD_LOG_DIRECTORIES_OPTION" />
               <option name="taskDescriptions">
                 <list />
               </option>

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTask.kt
@@ -78,6 +78,14 @@ abstract class RunIdeTask : JavaExec(), RunnableIdeAware, SplitModeAware, Plugin
     abstract val splitModeFrontendBootstrapClasspath: ConfigurableFileCollection
 
     /**
+     * Removes stale log directories before launching `runIde`, `runIdeBackend`, or `runIdeFrontend`.
+     *
+     * Default value: `false`
+     */
+    @get:Input
+    abstract val purgeOldLogDirectories: Property<Boolean>
+
+    /**
      * Executes the task, configures, and runs the IDE.
      */
     @TaskAction
@@ -86,6 +94,7 @@ abstract class RunIdeTask : JavaExec(), RunnableIdeAware, SplitModeAware, Plugin
         validateSplitModeSupport()
 
         workingDir = platformPath.toFile()
+        purgeOldLogDirectoriesIfRequested()
 
         if (composeHotReload.get() && executionMode.get() != ExecutionMode.SPLIT_MODE_FRONTEND) {
             log.info("Compose Hot Reload is enabled for `runIde` task")
@@ -205,6 +214,25 @@ abstract class RunIdeTask : JavaExec(), RunnableIdeAware, SplitModeAware, Plugin
         true
     }.getOrDefault(false)
 
+    private fun purgeOldLogDirectoriesIfRequested() {
+        if (!purgeOldLogDirectories.get()) {
+            return
+        }
+
+        when (executionMode.get()) {
+            ExecutionMode.STANDARD,
+            ExecutionMode.SPLIT_MODE_BACKEND, ExecutionMode.SPLIT_MODE_FRONTEND -> {
+                val sandboxLogPath = sandboxLogDirectory.asPath
+                if (sandboxLogPath.exists()) {
+                    log.info("Removing existing sandbox log directory at '${sandboxLogPath.safePathString}'.")
+                    sandboxLogPath.toFile().deleteRecursively()
+                    check(sandboxLogPath.notExists()) { "Failed to remove existing sandbox log directory: ${sandboxLogPath.safePathString}" }
+                }
+                sandboxLogPath.createDirectories()
+            }
+        }
+    }
+
     private fun configureSplitModeFrontendLaunch() {
         configureSplitModeSharedEnvironment()
         configureSplitModeFrontendDebugPort()
@@ -270,6 +298,7 @@ abstract class RunIdeTask : JavaExec(), RunnableIdeAware, SplitModeAware, Plugin
         description = "Runs the IDE instance using the currently selected IntelliJ Platform with the built plugin loaded."
         executionMode.convention(ExecutionMode.STANDARD)
         splitModeServerPort.convention(DEFAULT_SPLIT_MODE_SERVER_PORT)
+        purgeOldLogDirectories.convention(false)
     }
 
     companion object : Registrable {

--- a/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTask.kt
+++ b/src/main/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTask.kt
@@ -7,6 +7,7 @@ import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
+import org.gradle.api.tasks.options.Option
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.kotlin.dsl.named
 import org.gradle.process.JavaForkOptions
@@ -42,6 +43,7 @@ private const val SPLIT_MODE_HOST_PASSWORD_ENV = "CWM_HOST_PASSWORD"
 private const val SPLIT_MODE_CLIENT_PASSWORD_ENV = "CWM_CLIENT_PASSWORD"
 private const val SPLIT_MODE_NO_TIMEOUTS_ENV = "CWM_NO_TIMEOUTS"
 private const val SPLIT_MODE_SHARED_PASSWORD = "qwerty123"
+internal const val PURGE_OLD_LOG_DIRECTORIES_OPTION = "purge-old-log-directories"
 
 /**
  * Runs the IDE instance using the currently selected IntelliJ Platform with the built plugin loaded.
@@ -84,6 +86,14 @@ abstract class RunIdeTask : JavaExec(), RunnableIdeAware, SplitModeAware, Plugin
      */
     @get:Input
     abstract val purgeOldLogDirectories: Property<Boolean>
+
+    @Option(
+        option = PURGE_OLD_LOG_DIRECTORIES_OPTION,
+        description = "Removes stale sandbox log directories before launching the IDE."
+    )
+    fun setPurgeOldLogDirectoriesOption(value: Boolean) {
+        purgeOldLogDirectories.set(value)
+    }
 
     /**
      * Executes the task, configures, and runs the IDE.

--- a/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/GenerateSplitModeRunConfigurationsTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/GenerateSplitModeRunConfigurationsTaskTest.kt
@@ -24,7 +24,7 @@ class GenerateSplitModeRunConfigurationsTaskTest : IntelliJPluginTestBase() {
                   <option name="executionName" />
                   <option name="externalProjectPath" value="${'$'}PROJECT_DIR${'$'}" />
                   <option name="externalSystemIdString" value="GRADLE" />
-                  <option name="scriptParameters" value="" />
+                  <option name="scriptParameters" value="--purge-old-log-directories" />
                   <option name="taskDescriptions">
                     <list />
                   </option>
@@ -56,7 +56,7 @@ class GenerateSplitModeRunConfigurationsTaskTest : IntelliJPluginTestBase() {
                   <option name="executionName" />
                   <option name="externalProjectPath" value="${'$'}PROJECT_DIR${'$'}" />
                   <option name="externalSystemIdString" value="GRADLE" />
-                  <option name="scriptParameters" value="" />
+                  <option name="scriptParameters" value="--purge-old-log-directories" />
                   <option name="taskDescriptions">
                     <list />
                   </option>
@@ -142,7 +142,7 @@ class GenerateSplitModeRunConfigurationsTaskTest : IntelliJPluginTestBase() {
                   <option name="executionName" />
                   <option name="externalProjectPath" value="${'$'}PROJECT_DIR${'$'}" />
                   <option name="externalSystemIdString" value="GRADLE" />
-                  <option name="scriptParameters" value="" />
+                  <option name="scriptParameters" value="--purge-old-log-directories" />
                   <option name="taskDescriptions">
                     <list />
                   </option>
@@ -174,7 +174,7 @@ class GenerateSplitModeRunConfigurationsTaskTest : IntelliJPluginTestBase() {
                   <option name="executionName" />
                   <option name="externalProjectPath" value="${'$'}PROJECT_DIR${'$'}" />
                   <option name="externalSystemIdString" value="GRADLE" />
-                  <option name="scriptParameters" value="" />
+                  <option name="scriptParameters" value="--purge-old-log-directories" />
                   <option name="taskDescriptions">
                     <list />
                   </option>

--- a/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/GenerateSplitModeRunConfigurationsTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/GenerateSplitModeRunConfigurationsTaskTest.kt
@@ -19,6 +19,7 @@ class GenerateSplitModeRunConfigurationsTaskTest : IntelliJPluginTestBase() {
             """
             <component name="ProjectRunConfigurationManager">
               <configuration default="false" name="Run IDE (Backend)" type="GradleRunConfiguration" factoryName="Gradle">
+                <log_file alias="Backend IDE logs" path="${'$'}PROJECT_DIR$/.intellijPlatform/sandbox/*/*/log_runIdeBackend/idea.log" show_all="true" skipped="false" />
                 <ExternalSystemSettings>
                   <option name="executionName" />
                   <option name="externalProjectPath" value="${'$'}PROJECT_DIR${'$'}" />
@@ -50,6 +51,7 @@ class GenerateSplitModeRunConfigurationsTaskTest : IntelliJPluginTestBase() {
             """
             <component name="ProjectRunConfigurationManager">
               <configuration default="false" name="Run IDE (Frontend)" type="GradleRunConfiguration" factoryName="Gradle">
+                <log_file alias="Frontend IDE logs" path="${'$'}PROJECT_DIR$/.intellijPlatform/sandbox/*/*/log_runIdeFrontend/frontend/*/idea.log" show_all="true" skipped="false" />
                 <ExternalSystemSettings>
                   <option name="executionName" />
                   <option name="externalProjectPath" value="${'$'}PROJECT_DIR${'$'}" />
@@ -135,6 +137,7 @@ class GenerateSplitModeRunConfigurationsTaskTest : IntelliJPluginTestBase() {
             """
             <component name="ProjectRunConfigurationManager">
               <configuration default="false" name="Run IDE (Backend)" type="GradleRunConfiguration" factoryName="Gradle">
+                <log_file alias="Backend IDE logs" path="${'$'}PROJECT_DIR$/.intellijPlatform/sandbox/*/*/log_runIdeBackend/idea.log" show_all="true" skipped="false" />
                 <ExternalSystemSettings>
                   <option name="executionName" />
                   <option name="externalProjectPath" value="${'$'}PROJECT_DIR${'$'}" />
@@ -166,6 +169,7 @@ class GenerateSplitModeRunConfigurationsTaskTest : IntelliJPluginTestBase() {
             """
             <component name="ProjectRunConfigurationManager">
               <configuration default="false" name="Run IDE (Frontend)" type="GradleRunConfiguration" factoryName="Gradle">
+                <log_file alias="Frontend IDE logs" path="${'$'}PROJECT_DIR$/.intellijPlatform/sandbox/*/*/log_runIdeFrontend/frontend/*/idea.log" show_all="true" skipped="false" />
                 <ExternalSystemSettings>
                   <option name="executionName" />
                   <option name="externalProjectPath" value="${'$'}PROJECT_DIR${'$'}" />

--- a/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTaskTest.kt
@@ -64,7 +64,8 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
         val fakeJdk = dir.resolve("fake-jdk")
         val fakeLauncherClasses = fakeJdk.resolve("fake-launcher-classes")
         val fakeJavaExecutable = fakeJdk.resolve("bin/java${if (isWindows) ".exe" else ""}")
-        val realJavaExecutable = java.nio.file.Path.of(System.getProperty("java.home"), "bin", "java${if (isWindows) ".exe" else ""}")
+        val realJavaExecutable =
+            java.nio.file.Path.of(System.getProperty("java.home"), "bin", "java${if (isWindows) ".exe" else ""}")
 
         fakeJdk.resolve("bin").createDirectories()
         fakeJavaExecutable overwrite ""
@@ -402,6 +403,25 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
 
         build(Tasks.RUN_IDE_BACKEND)
 
+        assertFalse(staleLogFile.exists())
+        assertTrue(backendLogDirectory.exists())
+    }
+
+    @Test
+    fun `runIdeBackend removes old log directories when requested via task option`() {
+        configureFakeJavaLauncher()
+        val backendLogDirectory = sandbox.resolve("log_${Tasks.RUN_IDE_BACKEND}")
+        val staleLogFile = backendLogDirectory.resolve("old-session/idea.log")
+        staleLogFile.parent.createDirectories()
+        staleLogFile.toFile().writeText("stale")
+
+        val result = builder(
+            gradleVersion,
+            Tasks.RUN_IDE_BACKEND,
+            "--$PURGE_OLD_LOG_DIRECTORIES_OPTION",
+        ).build()
+
+        assertContains("APP_ARGS=serverMode -p 5990", result.output)
         assertFalse(staleLogFile.exists())
         assertTrue(backendLogDirectory.exists())
     }

--- a/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTaskTest.kt
+++ b/src/test/kotlin/org/jetbrains/intellij/platform/gradle/tasks/RunIdeTaskTest.kt
@@ -2,21 +2,29 @@
 
 package org.jetbrains.intellij.platform.gradle.tasks
 
+import org.jetbrains.intellij.platform.gradle.Constants.Sandbox
 import org.jetbrains.intellij.platform.gradle.Constants.Tasks
 import org.jetbrains.intellij.platform.gradle.IntelliJPluginTestBase
 import org.jetbrains.intellij.platform.gradle.assertContains
 import org.jetbrains.intellij.platform.gradle.assertNotContains
 import org.jetbrains.intellij.platform.gradle.buildFile
+import org.jetbrains.intellij.platform.gradle.cacheDirectory
 import org.jetbrains.intellij.platform.gradle.overwrite
 import org.jetbrains.intellij.platform.gradle.write
 import javax.tools.ToolProvider
 import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
 import kotlin.io.path.invariantSeparatorsPathString
 import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class RunIdeTaskTest : IntelliJPluginTestBase() {
 
     private val isWindows = System.getProperty("os.name").startsWith("Windows")
+    private val sandbox
+        get() = cacheDirectory.resolve(Sandbox.CONTAINER).resolve("projectName")
+            .resolve("$intellijPlatformType-$intellijPlatformVersion")
 
     private fun configureFrontendJoinLinkProvider(
         delayMs: Int,
@@ -282,6 +290,41 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
     }
 
     @Test
+    fun `runIde keeps old log directories by default`() {
+        configureFakeJavaLauncher()
+        val staleLogFile = sandbox.resolve("${Sandbox.LOG}/old-session/idea.log")
+        staleLogFile.parent.createDirectories()
+        staleLogFile.toFile().writeText("stale")
+
+        build(Tasks.RUN_IDE)
+
+        assertTrue(staleLogFile.exists())
+    }
+
+    @Test
+    fun `runIde removes old log directories when requested`() {
+        configureFakeJavaLauncher()
+        buildFile.toFile().appendText(
+            """
+
+            tasks.named<RunIdeTask>("${Tasks.RUN_IDE}") {
+                purgeOldLogDirectories.set(true)
+            }
+            """.trimIndent()
+        )
+
+        val logDirectory = sandbox.resolve(Sandbox.LOG)
+        val staleLogFile = logDirectory.resolve("old-session/idea.log")
+        staleLogFile.parent.createDirectories()
+        staleLogFile.toFile().writeText("stale")
+
+        build(Tasks.RUN_IDE)
+
+        assertFalse(staleLogFile.exists())
+        assertTrue(logDirectory.exists())
+    }
+
+    @Test
     fun `runIdeBackend launches serverMode on configured port`() {
         configureFakeJavaLauncher()
 
@@ -322,17 +365,62 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
             .toList()
 
         kotlin.test.assertEquals(1, joinLinkFiles.size)
-        kotlin.test.assertEquals("debug://localhost:5990#remoteId=Split%20Mode", joinLinkFiles.single().readText().trim())
+        kotlin.test.assertEquals(
+            "debug://localhost:5990#remoteId=Split%20Mode",
+            joinLinkFiles.single().readText().trim()
+        )
+    }
+
+    @Test
+    fun `runIdeBackend keeps old log directories by default`() {
+        configureFakeJavaLauncher()
+        val staleLogFile = sandbox.resolve("log_${Tasks.RUN_IDE_BACKEND}/old-session/idea.log")
+        staleLogFile.parent.createDirectories()
+        staleLogFile.toFile().writeText("stale")
+
+        build(Tasks.RUN_IDE_BACKEND)
+
+        assertTrue(staleLogFile.exists())
+    }
+
+    @Test
+    fun `runIdeBackend removes old log directories when requested`() {
+        configureFakeJavaLauncher()
+        buildFile.toFile().appendText(
+            """
+
+            tasks.named<RunIdeTask>("${Tasks.RUN_IDE_BACKEND}") {
+                purgeOldLogDirectories.set(true)
+            }
+            """.trimIndent()
+        )
+
+        val backendLogDirectory = sandbox.resolve("log_${Tasks.RUN_IDE_BACKEND}")
+        val staleLogFile = backendLogDirectory.resolve("old-session/idea.log")
+        staleLogFile.parent.createDirectories()
+        staleLogFile.toFile().writeText("stale")
+
+        build(Tasks.RUN_IDE_BACKEND)
+
+        assertFalse(staleLogFile.exists())
+        assertTrue(backendLogDirectory.exists())
     }
 
     @Test
     fun `runIdeFrontend uses debug join link written by debug backend`() {
         configureFakeJavaLauncher()
-        configureFrontendJoinLinkProvider(delayMs = 0, port = 6092, joinLink = "debug://localhost:6092#remoteId=Split%20Mode")
+        configureFrontendJoinLinkProvider(
+            delayMs = 0,
+            port = 6092,
+            joinLink = "debug://localhost:6092#remoteId=Split%20Mode"
+        )
 
         build(Tasks.RUN_IDE_FRONTEND) {
             assertContains("MAIN_CLASS=com.intellij.platform.runtime.loader.IntellijLoader", output)
-            assertContains("APP_ARGS=thinClient debug://localhost:6092#remoteId=Split%20Mode --refresh-split-mode-token=true", output)
+            assertContains(
+                "APP_ARGS=thinClient debug://localhost:6092#remoteId=Split%20Mode --refresh-split-mode-token=true",
+                output
+            )
         }
     }
 
@@ -343,7 +431,10 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
 
         build(Tasks.RUN_IDE_FRONTEND) {
             assertContains("MAIN_CLASS=com.intellij.platform.runtime.loader.IntellijLoader", output)
-            assertContains("APP_ARGS=thinClient tcp://127.0.0.1:6093#cb=fake&remoteId=Split%20Mode --refresh-split-mode-token=true", output)
+            assertContains(
+                "APP_ARGS=thinClient tcp://127.0.0.1:6093#cb=fake&remoteId=Split%20Mode --refresh-split-mode-token=true",
+                output
+            )
             assertContains("frontend.properties", output)
             assertContains("-Didea.platform.prefix=JetBrainsClient", output)
             assertNotContains("coroutines-javaagent", output)
@@ -357,8 +448,39 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
             assertNotContains("-Didea.log.path=", output)
             assertNotContains("-Didea.plugins.path=", output)
             assertNotContains("-Dplugin.path=", output)
-            assertNotContains("APP_ARGS=thinClient tcp://127.0.0.1:6093#cb=fake&remoteId=Split%20Mode splitMode", output)
+            assertNotContains(
+                "APP_ARGS=thinClient tcp://127.0.0.1:6093#cb=fake&remoteId=Split%20Mode splitMode",
+                output
+            )
         }
+    }
+
+    @Test
+    fun `runIdeFrontend removes old frontend log directories when requested`() {
+        configureFakeJavaLauncher()
+        configureFrontendJoinLinkProvider(delayMs = 0, port = 6096, joinLink = "tcp://127.0.0.1:6096#cb=fake")
+        buildFile.toFile().appendText(
+            """
+
+            tasks.named<RunIdeTask>("${Tasks.RUN_IDE_FRONTEND}") {
+                purgeOldLogDirectories.set(true)
+            }
+            """.trimIndent()
+        )
+
+        val frontendLogDirectory = sandbox.resolve("log_${Tasks.RUN_IDE_FRONTEND}/frontend")
+        val staleLogDirectoryOne = frontendLogDirectory.resolve("client-1")
+        val staleLogDirectoryTwo = frontendLogDirectory.resolve("client-2")
+        staleLogDirectoryOne.createDirectories()
+        staleLogDirectoryTwo.createDirectories()
+        staleLogDirectoryOne.resolve("idea.log").toFile().writeText("stale-1")
+        staleLogDirectoryTwo.resolve("idea.log").toFile().writeText("stale-2")
+
+        build(Tasks.RUN_IDE_FRONTEND)
+
+        assertFalse(staleLogDirectoryOne.exists())
+        assertFalse(staleLogDirectoryTwo.exists())
+        assertTrue(frontendLogDirectory.exists())
     }
 
     @Test
@@ -396,7 +518,10 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
 
         build(Tasks.RUN_IDE_FRONTEND) {
             assertContains("MAIN_CLASS=com.intellij.platform.runtime.loader.IntellijLoader", output)
-            assertContains("APP_ARGS=thinClient tcp://127.0.0.1:6094#cb=delayed&remoteId=Split%20Mode --refresh-split-mode-token=true", output)
+            assertContains(
+                "APP_ARGS=thinClient tcp://127.0.0.1:6094#cb=delayed&remoteId=Split%20Mode --refresh-split-mode-token=true",
+                output
+            )
         }
     }
 
@@ -411,8 +536,14 @@ class RunIdeTaskTest : IntelliJPluginTestBase() {
 
         build(Tasks.RUN_IDE_FRONTEND) {
             assertContains("MAIN_CLASS=com.intellij.platform.runtime.loader.IntellijLoader", output)
-            assertContains("APP_ARGS=thinClient tcp://127.0.0.1:6091#cb=fresh&remoteId=Split%20Mode --refresh-split-mode-token=true", output)
-            assertNotContains("APP_ARGS=thinClient tcp://127.0.0.1:6090#cb=stale&remoteId=Split%20Mode --refresh-split-mode-token=true", output)
+            assertContains(
+                "APP_ARGS=thinClient tcp://127.0.0.1:6091#cb=fresh&remoteId=Split%20Mode --refresh-split-mode-token=true",
+                output
+            )
+            assertNotContains(
+                "APP_ARGS=thinClient tcp://127.0.0.1:6090#cb=stale&remoteId=Split%20Mode --refresh-split-mode-token=true",
+                output
+            )
         }
     }
 }


### PR DESCRIPTION
An additional logs tab is shown for runIdeFrontend/Backend configurations.

For convenience, the generateSplitRunConfigurations task now creates configurations with log tabs enabled. It also cleans previously written logs before the new IDE start so that the user sees only relevant data, not stale